### PR TITLE
fix(redis-strings): prevent mapping tables deletion before cache purge

### DIFF
--- a/packages/nextjs-cache-handler/package.json
+++ b/packages/nextjs-cache-handler/package.json
@@ -29,7 +29,7 @@
         "dist/redis-strings.d.ts"
       ],
       "buffer-string-decorator": [
-        "buffer-string-decorator.d.ts"
+        "dist/buffer-string-decorator.d.ts"
       ]
     }
   },


### PR DESCRIPTION
This pull request ensures that fields stored in `__sharedTags__` and `__sharedTagsTtl__`  are never cleared before the actual corresponding cache is cleared. The guards against situations where, e.g., and item is removed from `__sharedTags__` but there was an error removing the actual cache. In such edge cases, there is no way to revalidate the cache for a tag, and old data will continue to be retrieved.

This could happen because the three operations took place concurrently inside a single `Promise.all`. This pull request moves the deletion of the actual cache to only take place after the other two operations complete successfully.
