### PR TITLE
Added buffer conversion for rscData and segmentData

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,14 @@ const compositeHandler = createHandler({
 
 This cache handler converts buffers from cached route values to strings on save and back to buffers on read.
 
-Next 15 decided to change type of data.value.body property from String to Buffer which conflicts with how data is serialized to redis.
+Next 15 decided to change types of some properties from String to Buffer which conflicts with how data is serialized to redis. It is recommended to use this handler with `redis-strings` in Next 15 as this handler make the following adjustment.
 
-It is recommended to use this handler with `redis-strings` in Next 15.
+- **Converts `body` `Buffer` to `string`**  
+  See: https://github.com/vercel/next.js/blob/f5444a16ec2ef7b82d30048890b613aa3865c1f1/packages/next/src/server/response-cache/types.ts#L97
+- **Converts `rscData` `string` to `Buffer`**  
+  See: https://github.com/vercel/next.js/blob/f5444a16ec2ef7b82d30048890b613aa3865c1f1/packages/next/src/server/response-cache/types.ts#L76
+- **Converts `segmentData` `Record<string, string>` to `Map<string, Buffer>`**  
+  See: https://github.com/vercel/next.js/blob/f5444a16ec2ef7b82d30048890b613aa3865c1f1/packages/next/src/server/response-cache/types.ts#L80
 
 ## Full example
 

--- a/packages/nextjs-cache-handler/package-lock.json
+++ b/packages/nextjs-cache-handler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fortedigital/nextjs-cache-handler",
-  "version": "1.1.2-alpha-2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fortedigital/nextjs-cache-handler",
-      "version": "1.1.2-alpha-2",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@neshca/cache-handler": "^1.9.0",
@@ -14,8 +14,8 @@
         "lru-cache": "11.1.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.23.0",
-        "@types/node": "22.13.14",
+        "@eslint/js": "^9.24.0",
+        "@types/node": "22.14.1",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.10.0",
@@ -24,11 +24,11 @@
         "rimraf": "6.0.1",
         "tsup": "^8.4.0",
         "tsx": "4.19.3",
-        "typescript": "^5.8.2",
-        "typescript-eslint": "^8.28.0"
+        "typescript": "^5.8.3",
+        "typescript-eslint": "^8.30.1"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.37.0"
+        "@rollup/rollup-linux-x64-gnu": "^4.40.0"
       },
       "peerDependencies": {
         "next": ">=13.5.1",
@@ -523,9 +523,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
-      "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.24.0.tgz",
+      "integrity": "sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1166,9 +1166,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.37.0.tgz",
-      "integrity": "sha512-pKivGpgJM5g8dwj0ywBwe/HeVAUSuVVJhUTa/URXjxvoyTT/AxsLTAbkHkDHG7qQxLoW2s3apEIl26uUe08LVQ==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.0.tgz",
+      "integrity": "sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==",
       "cpu": [
         "x64"
       ],
@@ -1258,27 +1258,27 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
-      "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.28.0.tgz",
-      "integrity": "sha512-lvFK3TCGAHsItNdWZ/1FkvpzCxTHUVuFrdnOGLMa0GGCFIbCgQWVk3CzCGdA7kM3qGVc+dfW9tr0Z/sHnGDFyg==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.30.1.tgz",
+      "integrity": "sha512-v+VWphxMjn+1t48/jO4t950D6KR8JaJuNXzi33Ve6P8sEmPr5k6CEXjdGwT6+LodVnEa91EQCtwjWNUCPweo+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.28.0",
-        "@typescript-eslint/type-utils": "8.28.0",
-        "@typescript-eslint/utils": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0",
+        "@typescript-eslint/scope-manager": "8.30.1",
+        "@typescript-eslint/type-utils": "8.30.1",
+        "@typescript-eslint/utils": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1298,16 +1298,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.28.0.tgz",
-      "integrity": "sha512-LPcw1yHD3ToaDEoljFEfQ9j2xShY367h7FZ1sq5NJT9I3yj4LHer1Xd1yRSOdYy9BpsrxU7R+eoDokChYM53lQ==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.30.1.tgz",
+      "integrity": "sha512-H+vqmWwT5xoNrXqWs/fesmssOW70gxFlgcMlYcBaWNPIEWDgLa4W9nkSPmhuOgLnXq9QYgkZ31fhDyLhleCsAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.28.0",
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/typescript-estree": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0",
+        "@typescript-eslint/scope-manager": "8.30.1",
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/typescript-estree": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1323,14 +1323,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.28.0.tgz",
-      "integrity": "sha512-u2oITX3BJwzWCapoZ/pXw6BCOl8rJP4Ij/3wPoGvY8XwvXflOzd1kLrDUUUAIEdJSFh+ASwdTHqtan9xSg8buw==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.30.1.tgz",
+      "integrity": "sha512-+C0B6ChFXZkuaNDl73FJxRYT0G7ufVPOSQkqkpM/U198wUwUFOtgo1k/QzFh1KjpBitaK7R1tgjVz6o9HmsRPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0"
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1341,14 +1341,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.28.0.tgz",
-      "integrity": "sha512-oRoXu2v0Rsy/VoOGhtWrOKDiIehvI+YNrDk5Oqj40Mwm0Yt01FC/Q7nFqg088d3yAsR1ZcZFVfPCTTFCe/KPwg==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.30.1.tgz",
+      "integrity": "sha512-64uBF76bfQiJyHgZISC7vcNz3adqQKIccVoKubyQcOnNcdJBvYOILV1v22Qhsw3tw3VQu5ll8ND6hycgAR5fEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.28.0",
-        "@typescript-eslint/utils": "8.28.0",
+        "@typescript-eslint/typescript-estree": "8.30.1",
+        "@typescript-eslint/utils": "8.30.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.0.1"
       },
@@ -1365,9 +1365,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.28.0.tgz",
-      "integrity": "sha512-bn4WS1bkKEjx7HqiwG2JNB3YJdC1q6Ue7GyGlwPHyt0TnVq6TtD/hiOdTZt71sq0s7UzqBFXD8t8o2e63tXgwA==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.30.1.tgz",
+      "integrity": "sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1379,14 +1379,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.28.0.tgz",
-      "integrity": "sha512-H74nHEeBGeklctAVUvmDkxB1mk+PAZ9FiOMPFncdqeRBXxk1lWSYraHw8V12b7aa6Sg9HOBNbGdSHobBPuQSuA==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.30.1.tgz",
+      "integrity": "sha512-kQQnxymiUy9tTb1F2uep9W6aBiYODgq5EMSk6Nxh4Z+BDUoYUSa029ISs5zTzKBFnexQEh71KqwjKnRz58lusQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0",
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1432,16 +1432,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.28.0.tgz",
-      "integrity": "sha512-OELa9hbTYciYITqgurT1u/SzpQVtDLmQMFzy/N8pQE+tefOyCWT79jHsav294aTqV1q1u+VzqDGbuujvRYaeSQ==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.30.1.tgz",
+      "integrity": "sha512-T/8q4R9En2tcEsWPQgB5BQ0XJVOtfARcUvOa8yJP3fh9M/mXraLxZrkCfGb6ChrO/V3W+Xbd04RacUEqk1CFEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.28.0",
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/typescript-estree": "8.28.0"
+        "@typescript-eslint/scope-manager": "8.30.1",
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/typescript-estree": "8.30.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1456,13 +1456,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.28.0.tgz",
-      "integrity": "sha512-hbn8SZ8w4u2pRwgQ1GlUrPKE+t2XvcCW5tTRF7j6SMYIuYG37XuzIW44JCZPa36evi0Oy2SnM664BlIaAuQcvg==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.30.1.tgz",
+      "integrity": "sha512-aEhgas7aJ6vZnNFC7K4/vMGDGyOiqWcYZPpIWrTKuTAlsvDNKy2GFDqh9smL+iq069ZvR0YzEeq0B8NJlLzjFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.28.0",
+        "@typescript-eslint/types": "8.30.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -3362,6 +3362,20 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.37.0.tgz",
+      "integrity": "sha512-pKivGpgJM5g8dwj0ywBwe/HeVAUSuVVJhUTa/URXjxvoyTT/AxsLTAbkHkDHG7qQxLoW2s3apEIl26uUe08LVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3885,9 +3899,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3899,15 +3913,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.28.0.tgz",
-      "integrity": "sha512-jfZtxJoHm59bvoCMYCe2BM0/baMswRhMmYhy+w6VfcyHrjxZ0OJe0tGasydCpIpA+A/WIJhTyZfb3EtwNC/kHQ==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.30.1.tgz",
+      "integrity": "sha512-D7lC0kcehVH7Mb26MRQi64LMyRJsj3dToJxM1+JVTl53DQSV5/7oUGWQLcKl1C1KnoVHxMMU2FNQMffr7F3Row==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.28.0",
-        "@typescript-eslint/parser": "8.28.0",
-        "@typescript-eslint/utils": "8.28.0"
+        "@typescript-eslint/eslint-plugin": "8.30.1",
+        "@typescript-eslint/parser": "8.30.1",
+        "@typescript-eslint/utils": "8.30.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3922,9 +3936,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/nextjs-cache-handler/package.json
+++ b/packages/nextjs-cache-handler/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/fortedigital/nextjs-cache-handler.git"
   },
-  "version": "1.2.0-alpha",
+  "version": "1.2.0",
   "type": "module",
   "license": "MIT",
   "description": "Next.js cache handlers",
@@ -53,8 +53,8 @@
     "lru-cache": "11.1.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.23.0",
-    "@types/node": "22.13.14",
+    "@eslint/js": "^9.24.0",
+    "@types/node": "22.14.1",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.0",
     "globals": "^15.10.0",
@@ -63,8 +63,8 @@
     "rimraf": "6.0.1",
     "tsup": "^8.4.0",
     "tsx": "4.19.3",
-    "typescript": "^5.8.2",
-    "typescript-eslint": "^8.28.0"
+    "typescript": "^5.8.3",
+    "typescript-eslint": "^8.30.1"
   },
   "peerDependencies": {
     "next": ">=13.5.1",
@@ -76,7 +76,7 @@
     "next15"
   ],
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.37.0"
+    "@rollup/rollup-linux-x64-gnu": "^4.40.0"
   },
   "files": [
     "dist"

--- a/packages/nextjs-cache-handler/package.json
+++ b/packages/nextjs-cache-handler/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/fortedigital/nextjs-cache-handler.git"
   },
-  "version": "1.1.4",
+  "version": "1.2.0-alpha",
   "type": "module",
   "license": "MIT",
   "description": "Next.js cache handlers",

--- a/packages/nextjs-cache-handler/src/handlers/buffer-string-decorator.ts
+++ b/packages/nextjs-cache-handler/src/handlers/buffer-string-decorator.ts
@@ -82,14 +82,14 @@ export default function bufferStringDecorator(handler: Handler): Handler {
         const appPageValue = value as unknown as CachedAppPageValue;
 
         if (appPageValue?.rscData) {
-          // Convert rscData string to Buffer
+          // Convert rscData Buffer to string
           // See: https://github.com/vercel/next.js/blob/f5444a16ec2ef7b82d30048890b613aa3865c1f1/packages/next/src/server/response-cache/types.ts#L76
 
           appPageData.rscData = appPageValue.rscData.toString();
         }
 
         if (appPageValue?.segmentData) {
-          // Convert segmentData Record<string, string> to Map<string, Buffer>
+          // Convert segmentData Map<string, Buffer> to Record<string, string>
           // See: https://github.com/vercel/next.js/blob/f5444a16ec2ef7b82d30048890b613aa3865c1f1/packages/next/src/server/response-cache/types.ts#L80
 
           appPageData.segmentData = Object.fromEntries(

--- a/packages/nextjs-cache-handler/src/handlers/buffer-string-decorator.ts
+++ b/packages/nextjs-cache-handler/src/handlers/buffer-string-decorator.ts
@@ -1,9 +1,10 @@
 import { Handler } from "@neshca/cache-handler";
-import { CachedRouteValue } from "next/dist/server/response-cache";
-
-type ConvertedStaticPageCacheData = CachedRouteValue & {
-  body: string;
-};
+import {
+  CachedAppPageValue,
+  CachedRouteValue,
+  ConvertedCachedAppPageValue,
+  ConvertedCachedRouteValue,
+} from "./buffer-string-decorator.types";
 
 /*
  * This cache handler converts buffers from cached route values to strings on save and back to buffers on read.
@@ -17,37 +18,89 @@ export default function bufferStringDecorator(handler: Handler): Handler {
 
     async get(key, ctx) {
       const hit = await handler.get(key, ctx);
-      const staticPageCacheData =
-        hit?.value as unknown as ConvertedStaticPageCacheData;
-      if (
-        hit?.value &&
-        (staticPageCacheData?.kind as string) === "APP_ROUTE" &&
-        staticPageCacheData?.body
-      ) {
-        return {
-          ...hit,
-          value: {
-            ...hit.value,
-            body: Buffer.from(staticPageCacheData.body, "utf-8"),
-          },
-        };
+
+      if (!hit?.value) {
+        return hit;
       }
+
+      const value = hit.value;
+      const kind = value?.kind as string;
+
+      if (kind === "APP_ROUTE") {
+        const appRouteData = value as unknown as ConvertedCachedRouteValue;
+
+        if (appRouteData?.body) {
+          // Convert body string to Buffer
+          // See: https://github.com/vercel/next.js/blob/f5444a16ec2ef7b82d30048890b613aa3865c1f1/packages/next/src/server/response-cache/types.ts#L97
+
+          const appRouteValue = value as unknown as CachedRouteValue;
+          appRouteValue.body = Buffer.from(appRouteData.body, "utf-8");
+        }
+      } else if (kind === "APP_PAGE") {
+        const appPageData = value as unknown as ConvertedCachedAppPageValue;
+        const appPageValue = value as unknown as CachedAppPageValue;
+
+        if (appPageData.rscData) {
+          // Convert rscData string to Buffer
+          // See: https://github.com/vercel/next.js/blob/f5444a16ec2ef7b82d30048890b613aa3865c1f1/packages/next/src/server/response-cache/types.ts#L76
+
+          appPageValue.rscData = Buffer.from(appPageData.rscData, "utf-8");
+        }
+
+        if (appPageData.segmentData) {
+          // Convert segmentData Record<string, string> to Map<string, Buffer>
+          // See: https://github.com/vercel/next.js/blob/f5444a16ec2ef7b82d30048890b613aa3865c1f1/packages/next/src/server/response-cache/types.ts#L80
+
+          appPageValue.segmentData = new Map(
+            Object.entries(appPageData.segmentData).map(([key, value]) => [
+              key,
+              Buffer.from(value, "utf-8"),
+            ]),
+          );
+        }
+      }
+
       return hit;
     },
 
     async set(key, data) {
-      const routeValue = data.value as unknown as CachedRouteValue;
-      if ((routeValue?.kind as string) === "APP_ROUTE" && routeValue?.body) {
-        await handler.set(key, {
-          ...data,
-          value: {
-            ...data.value,
-            body: routeValue.body.toString(),
-          } as ConvertedStaticPageCacheData,
-        });
-      } else {
-        await handler.set(key, data);
+      const value = data.value;
+      const kind = value?.kind as string;
+
+      if (kind === "APP_ROUTE") {
+        const appRouteData = value as unknown as ConvertedCachedRouteValue;
+        const appRouteValue = value as unknown as CachedRouteValue;
+
+        if (appRouteValue?.body) {
+          // Convert body Buffer to string
+          // See: https://github.com/vercel/next.js/blob/f5444a16ec2ef7b82d30048890b613aa3865c1f1/packages/next/src/server/response-cache/types.ts#L97
+
+          appRouteData.body = appRouteValue.body.toString();
+        }
+      } else if (kind === "APP_PAGE") {
+        const appPageData = value as unknown as ConvertedCachedAppPageValue;
+        const appPageValue = value as unknown as CachedAppPageValue;
+
+        if (appPageValue?.rscData) {
+          // Convert rscData string to Buffer
+          // See: https://github.com/vercel/next.js/blob/f5444a16ec2ef7b82d30048890b613aa3865c1f1/packages/next/src/server/response-cache/types.ts#L76
+
+          appPageData.rscData = appPageValue.rscData.toString();
+        }
+
+        if (appPageValue?.segmentData) {
+          // Convert segmentData Record<string, string> to Map<string, Buffer>
+          // See: https://github.com/vercel/next.js/blob/f5444a16ec2ef7b82d30048890b613aa3865c1f1/packages/next/src/server/response-cache/types.ts#L80
+
+          appPageData.segmentData = Object.fromEntries(
+            Array.from(appPageValue.segmentData.entries()).map(
+              ([key, value]) => [key, value.toString()],
+            ),
+          );
+        }
       }
+
+      await handler.set(key, data);
     },
 
     async revalidateTag(tag) {

--- a/packages/nextjs-cache-handler/src/handlers/buffer-string-decorator.types.ts
+++ b/packages/nextjs-cache-handler/src/handlers/buffer-string-decorator.types.ts
@@ -1,0 +1,23 @@
+export type CachedRouteValue = {
+  // See: https://github.com/vercel/next.js/blob/f5444a16ec2ef7b82d30048890b613aa3865c1f1/packages/next/src/server/response-cache/types.ts#L97
+  kind: "APP_ROUTE";
+  body: Buffer | undefined;
+};
+
+export type ConvertedCachedRouteValue = {
+  kind: "ROUTE";
+  body: string | undefined;
+};
+
+export type CachedAppPageValue = {
+  // See: https://github.com/vercel/next.js/blob/f5444a16ec2ef7b82d30048890b613aa3865c1f1/packages/next/src/server/response-cache/types.ts#L76
+  kind: "APP_PAGE";
+  rscData: Buffer | undefined;
+  segmentData: Map<string, Buffer> | undefined;
+};
+
+export type ConvertedCachedAppPageValue = {
+  kind: "PAGE";
+  rscData: string | undefined;
+  segmentData: Record<string, string> | undefined;
+};


### PR DESCRIPTION
This PR ensures `rscData` and `segmentData` are also converted from string to Bugger and vice-versa. 

Extra changes
- refactored conversion code to easier to read,
- upgraded packages (non-breaking changes).

Big shoutout to @omavi for discovering that `rscData` and `segmentData` need conversion a well https://github.com/vercel/next.js/discussions/74240#discussioncomment-12861804.