### PR TITLE
1.3.0 Fixed instrumentation and clientSegmentCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,43 @@
 
 This package extends the functionality of [`@neshca/cache-handler`](https://www.npmjs.com/package/@neshca/cache-handler) by providing additional cache handlers for specialized use cases, specifically for Redis-based caching solutions. The original `@neshca/cache-handler` offers a robust caching API for Next.js applications, and this package introduces two new handlers for managing Redis cache with different expiration strategies and tag-based revalidation.
 
+
+## Migration
+
+### 1.2.x -> 1.3.x
+
+#### cache-handler
+1.2.x
+```
+const { Next15CacheHandler } = require("@fortedigital/nextjs-cache-handler/next-15-cache-handler");
+module.exports = new Next15CacheHandler();
+```
+
+1.3.x
+```
+const { Next15CacheHandler } = require("@fortedigital/nextjs-cache-handler");
+module.exports = Next15CacheHandler;
+```
+
+#### instrumentation
+1.2.x
+```
+if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { registerInitialCache } = await import('@neshca/cache-handler/instrumentation')
+    const CacheHandler = (await import("./cache-handler.js")).default;
+    await registerInitialCache(CacheHandler);
+}
+```
+
+1.3.x
+```
+if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { registerInitialCache } = await import("@fortedigital/nextjs-cache-handler/instrumentation");
+    const CacheHandler = (await import("./cache-handler.js")).default;
+    await registerInitialCache(CacheHandler);
+}
+```
+
 ## Installation
 
 To install this package along with its dependencies:
@@ -53,15 +90,13 @@ Use this:
 
 ```js
 const { CacheHandler } = require("@neshca/cache-handler");
-const {
-  Next15CacheHandler,
-} = require("@fortedigital/nextjs-cache-handler/next-15-cache-handler");
+const { Next15CacheHandler } = require("@fortedigital/nextjs-cache-handler");
 
 CacheHandler.onCreation(() => {
   // your usual setup
 });
 
-module.exports = new Next15CacheHandler();
+module.exports = Next15CacheHandler;
 ```
 
 ### Instrumentation
@@ -270,7 +305,7 @@ CacheHandler.onCreation(() => {
   return global.cacheHandlerConfigPromise;
 });
 
-module.exports = new Next15CacheHandler();
+module.exports = Next15CacheHandler;
 ```
 
 ## Reference to Original Package

--- a/README.md
+++ b/README.md
@@ -64,6 +64,32 @@ CacheHandler.onCreation(() => {
 module.exports = new Next15CacheHandler();
 ```
 
+### Instrumentation
+
+Instead of:
+
+```js
+export async function register() {
+ if (process.env.NEXT_RUNTIME === 'nodejs') {
+   const { registerInitialCache } = await import('@neshca/cache-handler/instrumentation');
+   const CacheHandler = (await import('../cache-handler.mjs')).default;
+   await registerInitialCache(CacheHandler);
+ }
+}
+```
+
+Use this:
+
+```js
+export async function register() {
+ if (process.env.NEXT_RUNTIME === 'nodejs') {
+   const { registerInitialCache } = await import('@fortedigital/nextjs-cache-handler/instrumentation');
+   const CacheHandler = (await import('../cache-handler.mjs')).default;
+   await registerInitialCache(CacheHandler);
+ }
+}
+```
+
 ## Handlers
 
 ### 1. `redis-strings`
@@ -134,14 +160,14 @@ const { PHASE_PRODUCTION_BUILD } = require("next/constants");
 
 // @fortedigital/nextjs-cache-handler dependencies
 const createCompositeHandler =
-  require("@fortedigital/nextjs-cache-handler/composite").default;
+  require("@fortedigital/nextjs-cache-handler/handlers/composite").default;
 const createRedisHandler =
-  require("@fortedigital/nextjs-cache-handler/redis-strings").default;
+  require("@fortedigital/nextjs-cache-handler/handlers/redis-strings").default;
 const createBufferStringHandler =
-  require("@fortedigital/nextjs-cache-handler/buffer-string-decorator").default;
+  require("@fortedigital/nextjs-cache-handler/handlers/buffer-string-decorator").default;
 const {
   Next15CacheHandler,
-} = require("@fortedigital/nextjs-cache-handler/next-15-cache-handler");
+} = require("@fortedigital/nextjs-cache-handler");
 
 // Usual onCreation from @neshca/cache-handler
 CacheHandler.onCreation(() => {

--- a/README.md
+++ b/README.md
@@ -160,11 +160,11 @@ const { PHASE_PRODUCTION_BUILD } = require("next/constants");
 
 // @fortedigital/nextjs-cache-handler dependencies
 const createCompositeHandler =
-  require("@fortedigital/nextjs-cache-handler/handlers/composite").default;
+  require("@fortedigital/nextjs-cache-handler/composite").default;
 const createRedisHandler =
-  require("@fortedigital/nextjs-cache-handler/handlers/redis-strings").default;
+  require("@fortedigital/nextjs-cache-handler/redis-strings").default;
 const createBufferStringHandler =
-  require("@fortedigital/nextjs-cache-handler/handlers/buffer-string-decorator").default;
+  require("@fortedigital/nextjs-cache-handler/buffer-string-decorator").default;
 const {
   Next15CacheHandler,
 } = require("@fortedigital/nextjs-cache-handler");

--- a/packages/nextjs-cache-handler/package-lock.json
+++ b/packages/nextjs-cache-handler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fortedigital/nextjs-cache-handler",
-  "version": "1.2.0",
+  "version": "1.3.0-canary1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fortedigital/nextjs-cache-handler",
-      "version": "1.2.0",
+      "version": "1.3.0-canary1",
       "license": "MIT",
       "dependencies": {
         "@neshca/cache-handler": "^1.9.0",
@@ -14,21 +14,21 @@
         "lru-cache": "11.1.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.24.0",
-        "@types/node": "22.14.1",
+        "@eslint/js": "^9.27.0",
+        "@types/node": "22.15.27",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.0",
-        "globals": "^15.10.0",
+        "globals": "^15.15.0",
         "prettier": "^3.5.3",
-        "prettier-plugin-packagejson": "2.5.10",
+        "prettier-plugin-packagejson": "2.5.14",
         "rimraf": "6.0.1",
-        "tsup": "^8.4.0",
-        "tsx": "4.19.3",
+        "tsup": "^8.5.0",
+        "tsx": "4.19.4",
         "typescript": "^5.8.3",
-        "typescript-eslint": "^8.30.1"
+        "typescript-eslint": "^8.33.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.40.0"
+        "@rollup/rollup-linux-x64-gnu": "^4.41.1"
       },
       "peerDependencies": {
         "next": ">=13.5.1",
@@ -461,15 +461,19 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
@@ -523,13 +527,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.24.0.tgz",
-      "integrity": "sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
+      "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -679,16 +686,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/@next/env": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.26.tgz",
-      "integrity": "sha512-vO//GJ/YBco+H7xdQhzJxF7ub3SUwft76jwaeOyVVQFHCi5DCnkP16WHB+JBylo4vOKPoZBlR94Z8xBxNBdNJA==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.29.tgz",
+      "integrity": "sha512-UzgLR2eBfhKIQt0aJ7PWH7XRPYw7SXz0Fpzdl5THjUnvxy4kfBk9OU4RNPNiETewEEtaBcExNFNn1QWH8wQTjg==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.26.tgz",
-      "integrity": "sha512-zDJY8gsKEseGAxG+C2hTMT0w9Nk9N1Sk1qV7vXYz9MEiyRoF5ogQX2+vplyUMIfygnjn9/A04I6yrUTRTuRiyQ==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.29.tgz",
+      "integrity": "sha512-wWtrAaxCVMejxPHFb1SK/PVV1WDIrXGs9ki0C/kUM8ubKHQm+3hU9MouUywCw8Wbhj3pewfHT2wjunLEr/TaLA==",
       "cpu": [
         "arm64"
       ],
@@ -703,9 +710,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.26.tgz",
-      "integrity": "sha512-U0adH5ryLfmTDkahLwG9sUQG2L0a9rYux8crQeC92rPhi3jGQEY47nByQHrVrt3prZigadwj/2HZ1LUUimuSbg==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.29.tgz",
+      "integrity": "sha512-7Z/jk+6EVBj4pNLw/JQrvZVrAh9Bv8q81zCFSfvTMZ51WySyEHWVpwCEaJY910LyBftv2F37kuDPQm0w9CEXyg==",
       "cpu": [
         "x64"
       ],
@@ -720,9 +727,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.26.tgz",
-      "integrity": "sha512-SINMl1I7UhfHGM7SoRiw0AbwnLEMUnJ/3XXVmhyptzriHbWvPPbbm0OEVG24uUKhuS1t0nvN/DBvm5kz6ZIqpg==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.29.tgz",
+      "integrity": "sha512-o6hrz5xRBwi+G7JFTHc+RUsXo2lVXEfwh4/qsuWBMQq6aut+0w98WEnoNwAwt7hkEqegzvazf81dNiwo7KjITw==",
       "cpu": [
         "arm64"
       ],
@@ -737,9 +744,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.26.tgz",
-      "integrity": "sha512-s6JaezoyJK2DxrwHWxLWtJKlqKqTdi/zaYigDXUJ/gmx/72CrzdVZfMvUc6VqnZ7YEvRijvYo+0o4Z9DencduA==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.29.tgz",
+      "integrity": "sha512-9i+JEHBOVgqxQ92HHRFlSW1EQXqa/89IVjtHgOqsShCcB/ZBjTtkWGi+SGCJaYyWkr/lzu51NTMCfKuBf7ULNw==",
       "cpu": [
         "arm64"
       ],
@@ -754,9 +761,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.26.tgz",
-      "integrity": "sha512-FEXeUQi8/pLr/XI0hKbe0tgbLmHFRhgXOUiPScz2hk0hSmbGiU8aUqVslj/6C6KA38RzXnWoJXo4FMo6aBxjzg==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.29.tgz",
+      "integrity": "sha512-B7JtMbkUwHijrGBOhgSQu2ncbCYq9E7PZ7MX58kxheiEOwdkM+jGx0cBb+rN5AeqF96JypEppK6i/bEL9T13lA==",
       "cpu": [
         "x64"
       ],
@@ -771,9 +778,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.26.tgz",
-      "integrity": "sha512-BUsomaO4d2DuXhXhgQCVt2jjX4B4/Thts8nDoIruEJkhE5ifeQFtvW5c9JkdOtYvE5p2G0hcwQ0UbRaQmQwaVg==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.29.tgz",
+      "integrity": "sha512-yCcZo1OrO3aQ38B5zctqKU1Z3klOohIxug6qdiKO3Q3qNye/1n6XIs01YJ+Uf+TdpZQ0fNrOQI2HrTLF3Zprnw==",
       "cpu": [
         "x64"
       ],
@@ -788,9 +795,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.26.tgz",
-      "integrity": "sha512-5auwsMVzT7wbB2CZXQxDctpWbdEnEW/e66DyXO1DcgHxIyhP06awu+rHKshZE+lPLIGiwtjo7bsyeuubewwxMw==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.29.tgz",
+      "integrity": "sha512-WnrfeOEtTVidI9Z6jDLy+gxrpDcEJtZva54LYC0bSKQqmyuHzl0ego+v0F/v2aXq0am67BRqo/ybmmt45Tzo4A==",
       "cpu": [
         "arm64"
       ],
@@ -805,9 +812,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
-      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.29.tgz",
+      "integrity": "sha512-vkcriFROT4wsTdSeIzbxaZjTNTFKjSYmLd8q/GVH3Dn8JmYjUKOuKXHK8n+lovW/kdcpIvydO5GtN+It2CvKWA==",
       "cpu": [
         "ia32"
       ],
@@ -822,9 +829,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.26.tgz",
-      "integrity": "sha512-2rdB3T1/Gp7bv1eQTTm9d1Y1sv9UuJ2LAwOE0Pe2prHKe32UNscj7YS13fRB37d0GAiGNR+Y7ZcW8YjDI8Ns0w==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.29.tgz",
+      "integrity": "sha512-iPPwUEKnVs7pwR0EBLJlwxLD7TTHWS/AoVZx1l9ZQzfQciqaFEr5AlYzA2uB6Fyby1IF18t4PL0nTpB+k4Tzlw==",
       "cpu": [
         "x64"
       ],
@@ -884,16 +891,16 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
-      "integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
+      "integrity": "sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://opencollective.com/unts"
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@redis/bloom": {
@@ -1166,9 +1173,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.0.tgz",
-      "integrity": "sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.41.1.tgz",
+      "integrity": "sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==",
       "cpu": [
         "x64"
       ],
@@ -1258,9 +1265,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "version": "22.15.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.27.tgz",
+      "integrity": "sha512-5fF+eu5mwihV2BeVtX5vijhdaZOfkQTATrePEaXTcKqI16LhJ7gi2/Vhd9OZM0UojcdmiOCVg5rrax+i1MdoQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1268,21 +1275,21 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.30.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.30.1.tgz",
-      "integrity": "sha512-v+VWphxMjn+1t48/jO4t950D6KR8JaJuNXzi33Ve6P8sEmPr5k6CEXjdGwT6+LodVnEa91EQCtwjWNUCPweo+Q==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.33.0.tgz",
+      "integrity": "sha512-CACyQuqSHt7ma3Ns601xykeBK/rDeZa3w6IS6UtMQbixO5DWy+8TilKkviGDH6jtWCo8FGRKEK5cLLkPvEammQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.30.1",
-        "@typescript-eslint/type-utils": "8.30.1",
-        "@typescript-eslint/utils": "8.30.1",
-        "@typescript-eslint/visitor-keys": "8.30.1",
+        "@typescript-eslint/scope-manager": "8.33.0",
+        "@typescript-eslint/type-utils": "8.33.0",
+        "@typescript-eslint/utils": "8.33.0",
+        "@typescript-eslint/visitor-keys": "8.33.0",
         "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
+        "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1292,22 +1299,32 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "@typescript-eslint/parser": "^8.33.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
+      "integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.30.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.30.1.tgz",
-      "integrity": "sha512-H+vqmWwT5xoNrXqWs/fesmssOW70gxFlgcMlYcBaWNPIEWDgLa4W9nkSPmhuOgLnXq9QYgkZ31fhDyLhleCsAg==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.0.tgz",
+      "integrity": "sha512-JaehZvf6m0yqYp34+RVnihBAChkqeH+tqqhS0GuX1qgPpwLvmTPheKEs6OeCK6hVJgXZHJ2vbjnC9j119auStQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.30.1",
-        "@typescript-eslint/types": "8.30.1",
-        "@typescript-eslint/typescript-estree": "8.30.1",
-        "@typescript-eslint/visitor-keys": "8.30.1",
+        "@typescript-eslint/scope-manager": "8.33.0",
+        "@typescript-eslint/types": "8.33.0",
+        "@typescript-eslint/typescript-estree": "8.33.0",
+        "@typescript-eslint/visitor-keys": "8.33.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1322,15 +1339,16 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.30.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.30.1.tgz",
-      "integrity": "sha512-+C0B6ChFXZkuaNDl73FJxRYT0G7ufVPOSQkqkpM/U198wUwUFOtgo1k/QzFh1KjpBitaK7R1tgjVz6o9HmsRPg==",
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.0.tgz",
+      "integrity": "sha512-d1hz0u9l6N+u/gcrk6s6gYdl7/+pp8yHheRTqP6X5hVDKALEaTn8WfGiit7G511yueBEL3OpOEpD+3/MBdoN+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.30.1",
-        "@typescript-eslint/visitor-keys": "8.30.1"
+        "@typescript-eslint/tsconfig-utils": "^8.33.0",
+        "@typescript-eslint/types": "^8.33.0",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1340,17 +1358,52 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.30.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.30.1.tgz",
-      "integrity": "sha512-64uBF76bfQiJyHgZISC7vcNz3adqQKIccVoKubyQcOnNcdJBvYOILV1v22Qhsw3tw3VQu5ll8ND6hycgAR5fEA==",
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.0.tgz",
+      "integrity": "sha512-LMi/oqrzpqxyO72ltP+dBSP6V0xiUb4saY7WLtxSfiNEBI8m321LLVFU9/QDJxjDQG9/tjSqKz/E3380TEqSTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.30.1",
-        "@typescript-eslint/utils": "8.30.1",
+        "@typescript-eslint/types": "8.33.0",
+        "@typescript-eslint/visitor-keys": "8.33.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.0.tgz",
+      "integrity": "sha512-sTkETlbqhEoiFmGr1gsdq5HyVbSOF0145SYDJ/EQmXHtKViCaGvnyLqWFFHtEXoS0J1yU8Wyou2UGmgW88fEug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.33.0.tgz",
+      "integrity": "sha512-lScnHNCBqL1QayuSrWeqAL5GmqNdVUQAAMTaCwdYEdWfIrSrOGzyLGRCHXcCixa5NK6i5l0AfSO2oBSjCjf4XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.33.0",
+        "@typescript-eslint/utils": "8.33.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1365,9 +1418,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.30.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.30.1.tgz",
-      "integrity": "sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.0.tgz",
+      "integrity": "sha512-DKuXOKpM5IDT1FA2g9x9x1Ug81YuKrzf4mYX8FAVSNu5Wo/LELHWQyM1pQaDkI42bX15PWl0vNPt1uGiIFUOpg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1379,20 +1432,22 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.30.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.30.1.tgz",
-      "integrity": "sha512-kQQnxymiUy9tTb1F2uep9W6aBiYODgq5EMSk6Nxh4Z+BDUoYUSa029ISs5zTzKBFnexQEh71KqwjKnRz58lusQ==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.0.tgz",
+      "integrity": "sha512-vegY4FQoB6jL97Tu/lWRsAiUUp8qJTqzAmENH2k59SJhw0Th1oszb9Idq/FyyONLuNqT1OADJPXfyUNOR8SzAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.30.1",
-        "@typescript-eslint/visitor-keys": "8.30.1",
+        "@typescript-eslint/project-service": "8.33.0",
+        "@typescript-eslint/tsconfig-utils": "8.33.0",
+        "@typescript-eslint/types": "8.33.0",
+        "@typescript-eslint/visitor-keys": "8.33.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1432,16 +1487,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.30.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.30.1.tgz",
-      "integrity": "sha512-T/8q4R9En2tcEsWPQgB5BQ0XJVOtfARcUvOa8yJP3fh9M/mXraLxZrkCfGb6ChrO/V3W+Xbd04RacUEqk1CFEQ==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.0.tgz",
+      "integrity": "sha512-lPFuQaLA9aSNa7D5u2EpRiqdAUhzShwGg/nhpBlc4GR6kcTABttCuyjFs8BcEZ8VWrjCBof/bePhP3Q3fS+Yrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.30.1",
-        "@typescript-eslint/types": "8.30.1",
-        "@typescript-eslint/typescript-estree": "8.30.1"
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.33.0",
+        "@typescript-eslint/types": "8.33.0",
+        "@typescript-eslint/typescript-estree": "8.33.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1456,13 +1511,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.30.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.30.1.tgz",
-      "integrity": "sha512-aEhgas7aJ6vZnNFC7K4/vMGDGyOiqWcYZPpIWrTKuTAlsvDNKy2GFDqh9smL+iq069ZvR0YzEeq0B8NJlLzjFA==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.0.tgz",
+      "integrity": "sha512-7RW7CMYoskiz5OOGAWjJFxgb7c5UNjTG292gYhWeOAcFmYCtVCSqjqSBj5zMhxbXo2JOW95YYrUWJfU0zrpaGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/types": "8.33.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -1493,10 +1548,11 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1738,6 +1794,13 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
@@ -2179,6 +2242,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -2281,19 +2356,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/get-stdin": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
-      "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-tsconfig": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
@@ -2307,9 +2369,9 @@
       }
     },
     "node_modules/git-hooks-list": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-3.2.0.tgz",
-      "integrity": "sha512-ZHG9a1gEhUMX1TvGrLdyWb9kDopCBbTnI8z4JgRMYxsijWipgjSEYoPWqBuIB0DnRnvqlQSEeVmzpeuPm7NdFQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-4.1.1.tgz",
+      "integrity": "sha512-cmP497iLq54AZnv4YRAEMnEyQ1eIn4tGKbmswqwmFV4GBnAqE8NLtWxxdXa++AalfgL5EBH4IxTPyquEuGY/jA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2375,10 +2437,11 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.10.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.10.0.tgz",
-      "integrity": "sha512-tqFIbz83w4Y5TCbtgjZjApohbuh7K9BxGYFm7ifwDR240tvdb7P9x+/9VvUKlmkPoiknoJtanI8UOrqxS3a7lQ==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -2687,6 +2750,16 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2745,6 +2818,19 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
+      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "pathe": "^2.0.1",
+        "pkg-types": "^1.3.0",
+        "ufo": "^1.5.4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2788,13 +2874,13 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.26.tgz",
-      "integrity": "sha512-b81XSLihMwCfwiUVRRja3LphLo4uBBMZEzBBWMaISbKTwOmq3wPknIETy/8000tr7Gq4WmbuFYPS7jOYIf+ZJw==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.29.tgz",
+      "integrity": "sha512-s98mCOMOWLGGpGOfgKSnleXLuegvvH415qtRZXpSp00HeEgdmrxmwL9cgKU+h4XrhB16zEI5d/7BnkS3ATInsA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@next/env": "14.2.26",
+        "@next/env": "14.2.29",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -2809,15 +2895,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.26",
-        "@next/swc-darwin-x64": "14.2.26",
-        "@next/swc-linux-arm64-gnu": "14.2.26",
-        "@next/swc-linux-arm64-musl": "14.2.26",
-        "@next/swc-linux-x64-gnu": "14.2.26",
-        "@next/swc-linux-x64-musl": "14.2.26",
-        "@next/swc-win32-arm64-msvc": "14.2.26",
-        "@next/swc-win32-ia32-msvc": "14.2.26",
-        "@next/swc-win32-x64-msvc": "14.2.26"
+        "@next/swc-darwin-arm64": "14.2.29",
+        "@next/swc-darwin-x64": "14.2.29",
+        "@next/swc-linux-arm64-gnu": "14.2.29",
+        "@next/swc-linux-arm64-musl": "14.2.29",
+        "@next/swc-linux-x64-gnu": "14.2.29",
+        "@next/swc-linux-x64-musl": "14.2.29",
+        "@next/swc-win32-arm64-msvc": "14.2.29",
+        "@next/swc-win32-ia32-msvc": "14.2.29",
+        "@next/swc-win32-x64-msvc": "14.2.29"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -2970,6 +3056,13 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2996,6 +3089,18 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/postcss": {
@@ -3094,14 +3199,14 @@
       }
     },
     "node_modules/prettier-plugin-packagejson": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.10.tgz",
-      "integrity": "sha512-LUxATI5YsImIVSaaLJlJ3aE6wTD+nvots18U3GuQMJpUyClChaZlQrqx3dBnbhF20OnKWZyx8EgyZypQtBDtgQ==",
+      "version": "2.5.14",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.14.tgz",
+      "integrity": "sha512-h+3tSpr2nVpp+YOK1MDIYtYhHVXr8/0V59UUbJpIJFaqi3w4fvUokJo6eV8W+vELrUXIZzJ+DKm5G7lYzrMcKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "sort-package-json": "2.15.1",
-        "synckit": "0.9.2"
+        "sort-package-json": "3.2.1",
+        "synckit": "0.11.6"
       },
       "peerDependencies": {
         "prettier": ">= 1.16.0"
@@ -3409,9 +3514,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3462,20 +3567,19 @@
       "license": "MIT"
     },
     "node_modules/sort-package-json": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-2.15.1.tgz",
-      "integrity": "sha512-9x9+o8krTT2saA9liI4BljNjwAbvUnWf11Wq+i/iZt8nl2UGYnf3TH5uBydE7VALmP7AGwlfszuEeL8BDyb0YA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.2.1.tgz",
+      "integrity": "sha512-rTfRdb20vuoAn7LDlEtCqOkYfl2X+Qze6cLbNOzcDpbmKEhJI30tTN44d5shbKJnXsvz24QQhlCm81Bag7EOKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "detect-indent": "^7.0.1",
-        "detect-newline": "^4.0.0",
-        "get-stdin": "^9.0.0",
-        "git-hooks-list": "^3.0.0",
+        "detect-newline": "^4.0.1",
+        "git-hooks-list": "^4.0.0",
         "is-plain-obj": "^4.1.0",
-        "semver": "^7.6.0",
+        "semver": "^7.7.1",
         "sort-object-keys": "^1.1.3",
-        "tinyglobby": "^0.2.9"
+        "tinyglobby": "^0.2.12"
       },
       "bin": {
         "sort-package-json": "cli.js"
@@ -3671,20 +3775,19 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
-      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.6.tgz",
+      "integrity": "sha512-2pR2ubZSV64f/vqm9eLPz/KOvR9Dm+Co/5ChLgeHl0yEDRc6h5hXHoxEQH8Y5Ljycozd3p1k5TTSVdzYGkPvLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.1.0",
-        "tslib": "^2.6.2"
+        "@pkgr/core": "^0.2.4"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://opencollective.com/unts"
+        "url": "https://opencollective.com/synckit"
       }
     },
     "node_modules/text-table": {
@@ -3791,12 +3894,13 @@
     "node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "peer": true
     },
     "node_modules/tsup": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.4.0.tgz",
-      "integrity": "sha512-b+eZbPCjz10fRryaAA7C8xlIHnf8VnsaRqydheLIqwG/Mcpfk8Z5zp3HayX7GaTygkigHl5cBUs+IhcySiIexQ==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.0.tgz",
+      "integrity": "sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3806,6 +3910,7 @@
         "consola": "^3.4.0",
         "debug": "^4.4.0",
         "esbuild": "^0.25.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
         "joycon": "^3.1.1",
         "picocolors": "^1.1.1",
         "postcss-load-config": "^6.0.1",
@@ -3855,9 +3960,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
-      "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
+      "version": "4.19.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
+      "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3913,15 +4018,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.30.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.30.1.tgz",
-      "integrity": "sha512-D7lC0kcehVH7Mb26MRQi64LMyRJsj3dToJxM1+JVTl53DQSV5/7oUGWQLcKl1C1KnoVHxMMU2FNQMffr7F3Row==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.33.0.tgz",
+      "integrity": "sha512-5YmNhF24ylCsvdNW2oJwMzTbaeO4bg90KeGtMjUw0AGtHksgEPLRTUil+coHwCfiu4QjVJFnjp94DmU6zV7DhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.30.1",
-        "@typescript-eslint/parser": "8.30.1",
-        "@typescript-eslint/utils": "8.30.1"
+        "@typescript-eslint/eslint-plugin": "8.33.0",
+        "@typescript-eslint/parser": "8.33.0",
+        "@typescript-eslint/utils": "8.33.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3934,6 +4039,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/packages/nextjs-cache-handler/package.json
+++ b/packages/nextjs-cache-handler/package.json
@@ -30,23 +30,20 @@
   },
   "typesVersions": {
     "*": {
-      "Next15CacheHandler": [
+      "*": [
         "dist/handlers/next-15-cache-handler.d.ts"
+      ],
+      "instrumentation": [
+        "dist/instrumentation/instrumentation.d.ts"
+      ],
+      "buffer-string-decorator": [
+        "dist/handlers/buffer-string-decorator.d.ts"
       ],
       "composite": [
         "dist/handlers/composite.d.ts"
       ],
       "redis-strings": [
         "dist/handlers/redis-strings.d.ts"
-      ],
-      "buffer-string-decorator": [
-        "dist/handlers/buffer-string-decorator.d.ts"
-      ],
-      "instrumentation/instrumentation": [
-        "dist/instrumentation/instrumentation.d.ts"
-      ],
-      "instrumentation/register-initial-cache": [
-        "dist/instrumentation/register-initial-cache.d.ts"
       ]
     }
   },

--- a/packages/nextjs-cache-handler/package.json
+++ b/packages/nextjs-cache-handler/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/fortedigital/nextjs-cache-handler.git"
   },
-  "version": "1.3.0-canary5",
+  "version": "1.3.0",
   "type": "module",
   "license": "MIT",
   "description": "Next.js cache handlers",

--- a/packages/nextjs-cache-handler/package.json
+++ b/packages/nextjs-cache-handler/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/fortedigital/nextjs-cache-handler.git"
   },
-  "version": "1.3.0-canary4",
+  "version": "1.3.0-canary5",
   "type": "module",
   "license": "MIT",
   "description": "Next.js cache handlers",

--- a/packages/nextjs-cache-handler/package.json
+++ b/packages/nextjs-cache-handler/package.json
@@ -10,29 +10,43 @@
     "type": "git",
     "url": "git+https://github.com/fortedigital/nextjs-cache-handler.git"
   },
-  "version": "1.2.0",
+  "version": "1.3.0-canary",
   "type": "module",
   "license": "MIT",
   "description": "Next.js cache handlers",
   "exports": {
+    ".": {
+      "require": "./dist/cache-handler.cjs",
+      "import": "./dist/cache-handler.js"
+    },
     "./*": {
-      "require": "./dist/*.cjs",
-      "import": "./dist/*.js"
+      "require": "./dist/handlers/*.cjs",
+      "import": "./dist/handlers/*.js"
+    },
+    "./instrumentation": {
+      "require": "./dist/instrumentation/instrumentation.cjs",
+      "import": "./dist/instrumentation/instrumentation.js"
     }
   },
   "typesVersions": {
     "*": {
       "Next15CacheHandler": [
-        "dist/next-15-cache-handler.d.ts"
+        "dist/handlers/next-15-cache-handler.d.ts"
       ],
       "composite": [
-        "dist/composite.d.ts"
+        "dist/handlers/composite.d.ts"
       ],
       "redis-strings": [
-        "dist/redis-strings.d.ts"
+        "dist/handlers/redis-strings.d.ts"
       ],
       "buffer-string-decorator": [
-        "dist/buffer-string-decorator.d.ts"
+        "dist/handlers/buffer-string-decorator.d.ts"
+      ],
+      "instrumentation/instrumentation": [
+        "dist/instrumentation/instrumentation.d.ts"
+      ],
+      "instrumentation/register-initial-cache": [
+        "dist/instrumentation/register-initial-cache.d.ts"
       ]
     }
   },
@@ -53,18 +67,18 @@
     "lru-cache": "11.1.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.24.0",
-    "@types/node": "22.14.1",
+    "@eslint/js": "^9.27.0",
+    "@types/node": "22.15.27",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.0",
-    "globals": "^15.10.0",
+    "globals": "^15.15.0",
     "prettier": "^3.5.3",
-    "prettier-plugin-packagejson": "2.5.10",
+    "prettier-plugin-packagejson": "2.5.14",
     "rimraf": "6.0.1",
-    "tsup": "^8.4.0",
-    "tsx": "4.19.3",
+    "tsup": "^8.5.0",
+    "tsx": "4.19.4",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.30.1"
+    "typescript-eslint": "^8.33.0"
   },
   "peerDependencies": {
     "next": ">=13.5.1",
@@ -76,7 +90,7 @@
     "next15"
   ],
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.40.0"
+    "@rollup/rollup-linux-x64-gnu": "^4.41.1"
   },
   "files": [
     "dist"

--- a/packages/nextjs-cache-handler/package.json
+++ b/packages/nextjs-cache-handler/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/fortedigital/nextjs-cache-handler.git"
   },
-  "version": "1.3.0-canary",
+  "version": "1.3.0-canary1",
   "type": "module",
   "license": "MIT",
   "description": "Next.js cache handlers",

--- a/packages/nextjs-cache-handler/package.json
+++ b/packages/nextjs-cache-handler/package.json
@@ -16,8 +16,8 @@
   "description": "Next.js cache handlers",
   "exports": {
     ".": {
-      "require": "./dist/cache-handler.cjs",
-      "import": "./dist/cache-handler.js"
+      "require": "./dist/handlers/next-15-cache-handler.cjs",
+      "import": "./dist/handlers/next-15-cache-handler.js"
     },
     "./*": {
       "require": "./dist/handlers/*.cjs",

--- a/packages/nextjs-cache-handler/package.json
+++ b/packages/nextjs-cache-handler/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/fortedigital/nextjs-cache-handler.git"
   },
-  "version": "1.3.0-canary3",
+  "version": "1.3.0-canary4",
   "type": "module",
   "license": "MIT",
   "description": "Next.js cache handlers",

--- a/packages/nextjs-cache-handler/package.json
+++ b/packages/nextjs-cache-handler/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/fortedigital/nextjs-cache-handler.git"
   },
-  "version": "1.3.0-canary1",
+  "version": "1.3.0-canary3",
   "type": "module",
   "license": "MIT",
   "description": "Next.js cache handlers",

--- a/packages/nextjs-cache-handler/src/handlers/next-15-cache-handler.ts
+++ b/packages/nextjs-cache-handler/src/handlers/next-15-cache-handler.ts
@@ -9,23 +9,25 @@ import {
  * https://github.com/caching-tools/next-shared-cache/issues/1027
  * https://github.com/vercel/next.js/commit/6a1b6336a3062dfdb1b9dddcee6b836da94fd198
  */
-export class Next15CacheHandler extends CacheHandler {
-  async set(
-    cacheKey: string,
-    incrementalCacheValue: IncrementalCacheValue | null,
-    ctx: {
-      revalidate?: number | false;
-      fetchCache?: boolean;
-      fetchUrl?: string;
-      fetchIdx?: number;
-      tags?: string[];
-    } & { neshca_lastModified?: number },
-  ) {
-    await super.set(cacheKey, incrementalCacheValue, {
-      ...ctx,
-      revalidate:
-        ctx.revalidate ||
-        (incrementalCacheValue as CachedFetchValue)?.revalidate,
-    });
-  }
+export function Next15CacheHandler() {
+  return class extends CacheHandler {
+    async set(
+      cacheKey: string,
+      incrementalCacheValue: IncrementalCacheValue | null,
+      ctx: {
+        revalidate?: number | false;
+        fetchCache?: boolean;
+        fetchUrl?: string;
+        fetchIdx?: number;
+        tags?: string[];
+      } & { neshca_lastModified?: number },
+    ) {
+      await super.set(cacheKey, incrementalCacheValue, {
+        ...ctx,
+        revalidate:
+          ctx.revalidate ||
+          (incrementalCacheValue as CachedFetchValue)?.revalidate,
+      });
+    }
+  };
 }

--- a/packages/nextjs-cache-handler/src/handlers/next-15-cache-handler.ts
+++ b/packages/nextjs-cache-handler/src/handlers/next-15-cache-handler.ts
@@ -9,25 +9,23 @@ import {
  * https://github.com/caching-tools/next-shared-cache/issues/1027
  * https://github.com/vercel/next.js/commit/6a1b6336a3062dfdb1b9dddcee6b836da94fd198
  */
-export function Next15CacheHandler() {
-  return class extends CacheHandler {
-    async set(
-      cacheKey: string,
-      incrementalCacheValue: IncrementalCacheValue | null,
-      ctx: {
-        revalidate?: number | false;
-        fetchCache?: boolean;
-        fetchUrl?: string;
-        fetchIdx?: number;
-        tags?: string[];
-      } & { neshca_lastModified?: number },
-    ) {
-      await super.set(cacheKey, incrementalCacheValue, {
-        ...ctx,
-        revalidate:
-          ctx.revalidate ||
-          (incrementalCacheValue as CachedFetchValue)?.revalidate,
-      });
-    }
-  };
+export class Next15CacheHandler extends CacheHandler {
+  async set(
+    cacheKey: string,
+    incrementalCacheValue: IncrementalCacheValue | null,
+    ctx: {
+      revalidate?: number | false;
+      fetchCache?: boolean;
+      fetchUrl?: string;
+      fetchIdx?: number;
+      tags?: string[];
+    } & { neshca_lastModified?: number },
+  ) {
+    await super.set(cacheKey, incrementalCacheValue, {
+      ...ctx,
+      revalidate:
+        ctx.revalidate ||
+        (incrementalCacheValue as CachedFetchValue)?.revalidate,
+    });
+  }
 }

--- a/packages/nextjs-cache-handler/src/handlers/next-15-cache-handler.ts
+++ b/packages/nextjs-cache-handler/src/handlers/next-15-cache-handler.ts
@@ -1,33 +1,64 @@
 import { CacheHandler } from "@neshca/cache-handler";
+import { OutgoingHttpHeaders } from "http";
 import {
+  CachedRedirectValue,
+  CachedImageValue,
   CachedFetchValue,
   IncrementalCacheValue,
 } from "next/dist/server/response-cache";
+
+export interface CachedRouteValue {
+  kind: "APP_ROUTE";
+  body: Buffer;
+  status: number;
+  headers: OutgoingHttpHeaders;
+}
+
+interface IncrementalCachedPageValue {
+  kind: "APP_PAGE";
+  html: string;
+  pageData: Object;
+  postponed: string | undefined;
+  headers: OutgoingHttpHeaders | undefined;
+  status: number | undefined;
+}
+
+export type Next15IncrementalCacheValue =
+  | CachedRedirectValue
+  | IncrementalCachedPageValue
+  | CachedImageValue
+  | CachedFetchValue
+  | CachedRouteValue;
 
 /*
  * Use this handler in Next 15.2.1 and higher after `revalidate` property had been removed from context object.
  * https://github.com/caching-tools/next-shared-cache/issues/1027
  * https://github.com/vercel/next.js/commit/6a1b6336a3062dfdb1b9dddcee6b836da94fd198
  */
-export function Next15CacheHandler() {
-  return class extends CacheHandler {
-    async set(
-      cacheKey: string,
-      incrementalCacheValue: IncrementalCacheValue | null,
-      ctx: {
-        revalidate?: number | false;
-        fetchCache?: boolean;
-        fetchUrl?: string;
-        fetchIdx?: number;
-        tags?: string[];
-      } & { neshca_lastModified?: number },
-    ) {
-      await super.set(cacheKey, incrementalCacheValue, {
+export class Next15CacheHandler extends CacheHandler {
+  async set(
+    cacheKey: string,
+    incrementalCacheValue:
+      | IncrementalCacheValue
+      | Next15IncrementalCacheValue
+      | null,
+    ctx: {
+      revalidate?: number | false;
+      fetchCache?: boolean;
+      fetchUrl?: string;
+      fetchIdx?: number;
+      tags?: string[];
+    } & { neshca_lastModified?: number },
+  ) {
+    await super.set(
+      cacheKey,
+      incrementalCacheValue as unknown as IncrementalCacheValue,
+      {
         ...ctx,
         revalidate:
           ctx.revalidate ||
           (incrementalCacheValue as CachedFetchValue)?.revalidate,
-      });
-    }
-  };
+      },
+    );
+  }
 }

--- a/packages/nextjs-cache-handler/src/handlers/next-15-cache-handler.ts
+++ b/packages/nextjs-cache-handler/src/handlers/next-15-cache-handler.ts
@@ -1,34 +1,9 @@
 import { CacheHandler } from "@neshca/cache-handler";
-import { OutgoingHttpHeaders } from "http";
 import {
-  CachedRedirectValue,
-  CachedImageValue,
   CachedFetchValue,
   IncrementalCacheValue,
 } from "next/dist/server/response-cache";
-
-export interface CachedRouteValue {
-  kind: "APP_ROUTE";
-  body: Buffer;
-  status: number;
-  headers: OutgoingHttpHeaders;
-}
-
-interface IncrementalCachedPageValue {
-  kind: "APP_PAGE";
-  html: string;
-  pageData: Object;
-  postponed: string | undefined;
-  headers: OutgoingHttpHeaders | undefined;
-  status: number | undefined;
-}
-
-export type Next15IncrementalCacheValue =
-  | CachedRedirectValue
-  | IncrementalCachedPageValue
-  | CachedImageValue
-  | CachedFetchValue
-  | CachedRouteValue;
+import { Next15IncrementalCacheValue } from "./next15.types";
 
 /*
  * Use this handler in Next 15.2.1 and higher after `revalidate` property had been removed from context object.

--- a/packages/nextjs-cache-handler/src/handlers/next15.types.ts
+++ b/packages/nextjs-cache-handler/src/handlers/next15.types.ts
@@ -1,0 +1,29 @@
+import {
+  CachedRedirectValue,
+  CachedImageValue,
+  CachedFetchValue,
+} from "next/dist/server/response-cache";
+import { OutgoingHttpHeaders } from "http";
+
+export interface CachedRouteValue {
+  kind: "APP_ROUTE";
+  body: Buffer;
+  status: number;
+  headers: OutgoingHttpHeaders;
+}
+
+export interface IncrementalCachedPageValue {
+  kind: "APP_PAGE";
+  html: string;
+  pageData: Object;
+  postponed: string | undefined;
+  headers: OutgoingHttpHeaders | undefined;
+  status: number | undefined;
+}
+
+export type Next15IncrementalCacheValue =
+  | CachedRedirectValue
+  | IncrementalCachedPageValue
+  | CachedImageValue
+  | CachedFetchValue
+  | CachedRouteValue;

--- a/packages/nextjs-cache-handler/src/instrumentation/helpers/getTagsFromHeaders.ts
+++ b/packages/nextjs-cache-handler/src/instrumentation/helpers/getTagsFromHeaders.ts
@@ -1,0 +1,23 @@
+import type { OutgoingHttpHeaders } from "http";
+
+/**
+ * Retrieves the cache tags from the headers.
+ *
+ * @param headers - Headers object.
+ *
+ * @returns An array of cache tags.
+ */
+
+export function getTagsFromHeaders(headers: OutgoingHttpHeaders): string[] {
+    const tagsHeader = headers["x-next-cache-tags"];
+
+    if (Array.isArray(tagsHeader)) {
+        return tagsHeader;
+    }
+
+    if (typeof tagsHeader === "string") {
+        return tagsHeader.split(",");
+    }
+
+    return [];
+}

--- a/packages/nextjs-cache-handler/src/instrumentation/helpers/getTagsFromHeaders.ts
+++ b/packages/nextjs-cache-handler/src/instrumentation/helpers/getTagsFromHeaders.ts
@@ -9,15 +9,15 @@ import type { OutgoingHttpHeaders } from "http";
  */
 
 export function getTagsFromHeaders(headers: OutgoingHttpHeaders): string[] {
-    const tagsHeader = headers["x-next-cache-tags"];
+  const tagsHeader = headers["x-next-cache-tags"];
 
-    if (Array.isArray(tagsHeader)) {
-        return tagsHeader;
-    }
+  if (Array.isArray(tagsHeader)) {
+    return tagsHeader;
+  }
 
-    if (typeof tagsHeader === "string") {
-        return tagsHeader.split(",");
-    }
+  if (typeof tagsHeader === "string") {
+    return tagsHeader.split(",");
+  }
 
-    return [];
+  return [];
 }

--- a/packages/nextjs-cache-handler/src/instrumentation/instrumentation.ts
+++ b/packages/nextjs-cache-handler/src/instrumentation/instrumentation.ts
@@ -1,0 +1,4 @@
+export {
+  registerInitialCache,
+  type RegisterInitialCacheOptions,
+} from './register-initial-cache';

--- a/packages/nextjs-cache-handler/src/instrumentation/instrumentation.ts
+++ b/packages/nextjs-cache-handler/src/instrumentation/instrumentation.ts
@@ -1,4 +1,4 @@
 export {
   registerInitialCache,
   type RegisterInitialCacheOptions,
-} from './register-initial-cache';
+} from "./register-initial-cache";

--- a/packages/nextjs-cache-handler/src/instrumentation/register-initial-cache.ts
+++ b/packages/nextjs-cache-handler/src/instrumentation/register-initial-cache.ts
@@ -10,6 +10,8 @@ import { CachedFetchValue } from "next/dist/server/response-cache";
 import type { OutgoingHttpHeaders } from "http";
 import { getTagsFromHeaders } from "./helpers/getTagsFromHeaders";
 
+type CacheHandlerType = typeof import('../handlers/next-15-cache-handler').Next15CacheHandler;
+
 type NextRouteMetadata = {
   status: number | undefined;
   headers: OutgoingHttpHeaders | undefined;
@@ -80,7 +82,7 @@ export type RegisterInitialCacheOptions = {
  *
  */
 export async function registerInitialCache(
-  CacheHandler: CacheHandler,
+  CacheHandler: CacheHandlerType,
   options: RegisterInitialCacheOptions = {},
 ) {
   const debug = typeof process.env.NEXT_PRIVATE_DEBUG_CACHE !== "undefined";
@@ -125,11 +127,11 @@ export async function registerInitialCache(
     dev: process.env.NODE_ENV === "development",
   };
 
-  let cacheHandler: CacheHandler;
+  let cacheHandler: InstanceType<CacheHandlerType>;
 
   try {
-    cacheHandler = new Next15CacheHandler(
-      context as ConstructorParameters<typeof Next15CacheHandler>[0],
+    cacheHandler = new CacheHandler(
+      context as ConstructorParameters<typeof CacheHandler>[0],
     );
   } catch (error) {
     if (debug) {

--- a/packages/nextjs-cache-handler/src/instrumentation/register-initial-cache.ts
+++ b/packages/nextjs-cache-handler/src/instrumentation/register-initial-cache.ts
@@ -3,14 +3,13 @@ import path from "node:path";
 import { PRERENDER_MANIFEST, SERVER_DIRECTORY } from "next/constants";
 import type { PrerenderManifest } from "next/dist/build";
 import { CACHE_ONE_YEAR } from "next/dist/lib/constants";
-import { CacheHandler } from "@neshca/cache-handler";
-import { Next15CacheHandler } from "../handlers/next-15-cache-handler";
 import { Revalidate } from "next/dist/server/lib/revalidate";
 import { CachedFetchValue } from "next/dist/server/response-cache";
 import type { OutgoingHttpHeaders } from "http";
 import { getTagsFromHeaders } from "./helpers/getTagsFromHeaders";
 
-type CacheHandlerType = typeof import('../handlers/next-15-cache-handler').Next15CacheHandler;
+type CacheHandlerType =
+  typeof import("../handlers/next-15-cache-handler").Next15CacheHandler;
 
 type NextRouteMetadata = {
   status: number | undefined;
@@ -202,7 +201,7 @@ export async function registerInitialCache(
       await cacheHandler.set(
         cachePath,
         {
-          kind: "ROUTE",
+          kind: "APP_ROUTE",
           body,
           headers: meta.headers,
           status: meta.status,
@@ -289,7 +288,7 @@ export async function registerInitialCache(
       await cacheHandler.set(
         cachePath,
         {
-          kind: "PAGE",
+          kind: "APP_PAGE",
           html,
           pageData,
           postponed: meta?.postponed,

--- a/packages/nextjs-cache-handler/src/instrumentation/register-initial-cache.ts
+++ b/packages/nextjs-cache-handler/src/instrumentation/register-initial-cache.ts
@@ -1,0 +1,406 @@
+import { promises as fsPromises } from "node:fs";
+import path from "node:path";
+import { PRERENDER_MANIFEST, SERVER_DIRECTORY } from "next/constants";
+import type { PrerenderManifest } from "next/dist/build";
+import { CACHE_ONE_YEAR } from "next/dist/lib/constants";
+import { CacheHandler } from "@neshca/cache-handler";
+import { Next15CacheHandler } from "../handlers/next-15-cache-handler";
+import { Revalidate } from "next/dist/server/lib/revalidate";
+import { CachedFetchValue } from "next/dist/server/response-cache";
+import type { OutgoingHttpHeaders } from "http";
+import { getTagsFromHeaders } from "./helpers/getTagsFromHeaders";
+
+type NextRouteMetadata = {
+  status: number | undefined;
+  headers: OutgoingHttpHeaders | undefined;
+  postponed: string | undefined;
+};
+
+type Router = "pages" | "app";
+
+const PRERENDER_MANIFEST_VERSION = 4;
+
+/**
+ * Options for the `registerInitialCache` instrumentation.
+ */
+export type RegisterInitialCacheOptions = {
+  /**
+   * Whether to populate the cache with fetch calls.
+   *
+   * @default true
+   */
+  fetch?: boolean;
+  /**
+   * Whether to populate the cache with pre-rendered pages.
+   *
+   * @default true
+   */
+  pages?: boolean;
+  /**
+   * Whether to populate the cache with routes.
+   *
+   * @default true
+   */
+  routes?: boolean;
+};
+
+/**
+ * Populates the cache with the initial data.
+ *
+ * By default, it includes the following:
+ * - Pre-rendered pages
+ * - Routes
+ * - Fetch calls
+ *
+ * @param CacheHandler - The configured CacheHandler class, not an instance.
+ *
+ * @param [options={}] - Options for the instrumentation. See {@link RegisterInitialCacheOptions}.
+ *
+ * @param [options.fetch=true] - Whether to populate the cache with fetch calls.
+ *
+ * @param [options.pages=true] - Whether to populate the cache with pre-rendered pages.
+ *
+ * @param [options.routes=true] - Whether to populate the cache with routes.
+ *
+ * @example file: `instrumentation.ts`
+ *
+ * ```js
+ * export async function register() {
+ *  if (process.env.NEXT_RUNTIME === 'nodejs') {
+ *    const { registerInitialCache } = await import('@neshca/cache-handler/instrumentation');
+ *    // Assuming that your CacheHandler configuration is in the root of the project and the instrumentation is in the src directory.
+ *    // Please adjust the path accordingly.
+ *    // CommonJS CacheHandler configuration is also supported.
+ *    const CacheHandler = (await import('../cache-handler.mjs')).default;
+ *    await registerInitialCache(CacheHandler);
+ *  }
+ * }
+ * ```
+ *
+ *
+ */
+export async function registerInitialCache(
+  CacheHandler: CacheHandler,
+  options: RegisterInitialCacheOptions = {},
+) {
+  const debug = typeof process.env.NEXT_PRIVATE_DEBUG_CACHE !== "undefined";
+  const nextJsPath = path.join(process.cwd(), ".next");
+  const prerenderManifestPath = path.join(nextJsPath, PRERENDER_MANIFEST);
+  const serverDistDir = path.join(nextJsPath, SERVER_DIRECTORY);
+  const fetchCacheDir = path.join(nextJsPath, "cache", "fetch-cache");
+
+  const populateFetch = options.fetch ?? true;
+  const populatePages = options.pages ?? true;
+  const populateRoutes = options.routes ?? true;
+
+  let prerenderManifest: PrerenderManifest | undefined;
+
+  try {
+    const prerenderManifestData = await fsPromises.readFile(
+      prerenderManifestPath,
+      "utf-8",
+    );
+    prerenderManifest = JSON.parse(prerenderManifestData) as PrerenderManifest;
+
+    if (prerenderManifest.version !== PRERENDER_MANIFEST_VERSION) {
+      throw new Error(
+        `Invalid prerender manifest version. Expected version ${PRERENDER_MANIFEST_VERSION}. Please check if the Next.js version is compatible with the CacheHandler version.`,
+      );
+    }
+  } catch (error) {
+    if (debug) {
+      console.warn(
+        "[CacheHandler] [%s] %s %s",
+        "registerInitialCache",
+        "Failed to read prerender manifest",
+        `Error: ${error}`,
+      );
+    }
+
+    return;
+  }
+
+  const context = {
+    serverDistDir,
+    dev: process.env.NODE_ENV === "development",
+  };
+
+  let cacheHandler: CacheHandler;
+
+  try {
+    cacheHandler = new Next15CacheHandler(
+      context as ConstructorParameters<typeof Next15CacheHandler>[0],
+    );
+  } catch (error) {
+    if (debug) {
+      console.warn(
+        "[CacheHandler] [%s] %s %s",
+        "registerInitialCache",
+        "Failed to create CacheHandler instance",
+        `Error: ${error}`,
+      );
+    }
+
+    return;
+  }
+
+  async function setRouteCache(
+    cachePath: string,
+    router: Router,
+    revalidate: Revalidate,
+  ) {
+    const pathToRouteFiles = path.join(serverDistDir, router, cachePath);
+
+    let lastModified: number | undefined;
+
+    try {
+      const stats = await fsPromises.stat(`${pathToRouteFiles}.body`);
+      lastModified = stats.mtimeMs;
+    } catch (error) {
+      if (debug) {
+        console.warn(
+          "[CacheHandler] [%s] %s %s",
+          "registerInitialCache",
+          "Failed to read route body file",
+          `Error: ${error}`,
+        );
+      }
+
+      return;
+    }
+
+    let body: Buffer;
+    let meta: NextRouteMetadata;
+
+    try {
+      [body, meta] = await Promise.all([
+        fsPromises.readFile(`${pathToRouteFiles}.body`),
+        fsPromises
+          .readFile(`${pathToRouteFiles}.meta`, "utf-8")
+          .then((data) => JSON.parse(data) as NextRouteMetadata),
+      ]);
+
+      if (!(meta.headers && meta.status)) {
+        throw new Error("Invalid route metadata. Missing headers or status.");
+      }
+    } catch (error) {
+      if (debug) {
+        console.warn(
+          "[CacheHandler] [%s] %s %s",
+          "registerInitialCache",
+          "Failed to read route body or metadata file, or parse metadata",
+          `Error: ${error}`,
+        );
+      }
+
+      return;
+    }
+
+    try {
+      await cacheHandler.set(
+        cachePath,
+        {
+          kind: "ROUTE",
+          body,
+          headers: meta.headers,
+          status: meta.status,
+        },
+        {
+          revalidate,
+          neshca_lastModified: lastModified,
+          tags: getTagsFromHeaders(meta.headers),
+        },
+      );
+    } catch (error) {
+      if (debug) {
+        console.warn(
+          "[CacheHandler] [%s] %s %s",
+          "registerInitialCache",
+          "Failed to set route cache. Please check if the CacheHandler is configured correctly",
+          `Error: ${error}`,
+        );
+      }
+
+      return;
+    }
+  }
+
+  async function setPageCache(
+    cachePath: string,
+    router: Router,
+    revalidate: Revalidate,
+  ) {
+    const pathToRouteFiles = path.join(serverDistDir, router, cachePath);
+
+    const isAppRouter = router === "app";
+
+    let lastModified: number | undefined;
+
+    try {
+      const stats = await fsPromises.stat(`${pathToRouteFiles}.html`);
+      lastModified = stats.mtimeMs;
+    } catch (error) {
+      if (debug) {
+        console.warn(
+          "[CacheHandler] [%s] %s %s",
+          "registerInitialCache",
+          "Failed to read page html file",
+          `Error: ${error}`,
+        );
+      }
+      return;
+    }
+
+    let html: string | undefined;
+    let pageData: string | object | undefined;
+    let meta: NextRouteMetadata | undefined;
+
+    try {
+      [html, pageData, meta] = await Promise.all([
+        fsPromises.readFile(`${pathToRouteFiles}.html`, "utf-8"),
+        fsPromises
+          .readFile(
+            `${pathToRouteFiles}.${isAppRouter ? "rsc" : "json"}`,
+            "utf-8",
+          )
+          .then((data) => (isAppRouter ? data : (JSON.parse(data) as object))),
+        isAppRouter
+          ? fsPromises
+              .readFile(`${pathToRouteFiles}.meta`, "utf-8")
+              .then((data) => JSON.parse(data) as NextRouteMetadata)
+          : undefined,
+      ]);
+    } catch (error) {
+      if (debug) {
+        console.warn(
+          "[CacheHandler] [%s] %s %s",
+          "registerInitialCache",
+          "Failed to read page html, page data, or metadata file, or parse metadata",
+          `Error: ${error}`,
+        );
+      }
+
+      return;
+    }
+
+    try {
+      await cacheHandler.set(
+        cachePath,
+        {
+          kind: "PAGE",
+          html,
+          pageData,
+          postponed: meta?.postponed,
+          headers: meta?.headers,
+          status: meta?.status,
+        },
+        { revalidate, neshca_lastModified: lastModified },
+      );
+    } catch (error) {
+      if (debug) {
+        console.warn(
+          "[CacheHandler] [%s] %s %s",
+          "registerInitialCache",
+          "Failed to set page cache. Please check if the CacheHandler is configured correctly",
+          `Error: ${error}`,
+        );
+      }
+
+      return;
+    }
+  }
+
+  for (const [
+    cachePath,
+    { dataRoute, initialRevalidateSeconds },
+  ] of Object.entries(prerenderManifest.routes)) {
+    if (populatePages && dataRoute?.endsWith(".json")) {
+      await setPageCache(cachePath, "pages", initialRevalidateSeconds);
+    } else if (populatePages && dataRoute?.endsWith(".rsc")) {
+      await setPageCache(cachePath, "app", initialRevalidateSeconds);
+    } else if (populateRoutes && dataRoute === null) {
+      await setRouteCache(cachePath, "app", initialRevalidateSeconds);
+    }
+  }
+
+  if (!populateFetch) {
+    return;
+  }
+
+  let fetchFiles: string[];
+
+  try {
+    fetchFiles = await fsPromises.readdir(fetchCacheDir);
+  } catch (error) {
+    if (debug) {
+      console.warn(
+        "[CacheHandler] [%s] %s %s",
+        "registerInitialCache",
+        "Failed to read cache/fetch-cache directory",
+        `Error: ${error}`,
+      );
+    }
+
+    return;
+  }
+
+  for (const fetchCacheKey of fetchFiles) {
+    const filePath = path.join(fetchCacheDir, fetchCacheKey);
+
+    let lastModified: number | undefined;
+
+    try {
+      const stats = await fsPromises.stat(filePath);
+      lastModified = stats.mtimeMs;
+    } catch (error) {
+      if (debug) {
+        console.warn(
+          "[CacheHandler] [%s] %s %s",
+          "registerInitialCache",
+          "Failed to read fetch cache file",
+          `Error: ${error}`,
+        );
+      }
+      return;
+    }
+
+    let fetchCache: CachedFetchValue;
+    try {
+      fetchCache = await fsPromises
+        .readFile(filePath, "utf-8")
+        .then((data) => JSON.parse(data) as CachedFetchValue);
+    } catch (error) {
+      if (debug) {
+        console.warn(
+          "[CacheHandler] [%s] %s %s",
+          "registerInitialCache",
+          "Failed to parse fetch cache file",
+          `Error: ${error}`,
+        );
+      }
+
+      return;
+    }
+
+    // HACK: By default, Next.js sets the revalidate option to CACHE_ONE_YEAR if the revalidate option is set
+    const revalidate =
+      fetchCache.revalidate === CACHE_ONE_YEAR ? false : fetchCache.revalidate;
+
+    try {
+      await cacheHandler.set(fetchCacheKey, fetchCache, {
+        revalidate,
+        neshca_lastModified: lastModified,
+        tags: fetchCache.tags,
+      });
+    } catch (error) {
+      if (debug) {
+        console.warn(
+          "[CacheHandler] [%s] %s %s",
+          "registerInitialCache",
+          "Failed to set fetch cache. Please check if the CacheHandler is configured correctly",
+          `Error: ${error}`,
+        );
+      }
+    }
+  }
+}

--- a/packages/nextjs-cache-handler/tsup.config.ts
+++ b/packages/nextjs-cache-handler/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export const tsup = defineConfig({
   name: "Build cache-handler",
-  entry: ["src/handlers/*.ts"],
+  entry: ["src/handlers/*.ts", "src/instrumentation/*.ts"],
   splitting: false,
   outDir: "dist",
   clean: false,


### PR DESCRIPTION
# Fixes
- #10 
Using Next experimental config `clientSegmentCache: true` does not cause `createBufferStringHandler` to throw `cachedData.segmentData.get is not a function` anymore
- #11 
Using instrumentation is now supported to call `registerInitialCache`

# Breaking changes / migration
## cache-handler
1.2.x
```
const { Next15CacheHandler } = require("@fortedigital/nextjs-cache-handler/next-15-cache-handler");
module.exports = new Next15CacheHandler();
```

1.3.x
```
const { Next15CacheHandler } = require("@fortedigital/nextjs-cache-handler");
module.exports = Next15CacheHandler;
```

## instrumentation
1.2.x
```
if (process.env.NEXT_RUNTIME === "nodejs") {
    const { registerInitialCache } = await import('@neshca/cache-handler/instrumentation')
    const CacheHandler = (await import("./cache-handler.js")).default;
    await registerInitialCache(CacheHandler);
}
```

1.3.x
```
if (process.env.NEXT_RUNTIME === "nodejs") {
    const { registerInitialCache } = await import("@fortedigital/nextjs-cache-handler/instrumentation");
    const CacheHandler = (await import("./cache-handler.js")).default;
    await registerInitialCache(CacheHandler);
}
```