### PR TITLE
fix: Setting shared tags when not explicitly defined

### DIFF
--- a/packages/nextjs-cache-handler/src/handlers/redis-strings.ts
+++ b/packages/nextjs-cache-handler/src/handlers/redis-strings.ts
@@ -252,15 +252,12 @@ export default function createHandler({
       let expireOperation: Promise<boolean> | undefined;
       const lifespan = cacheHandlerValue.lifespan;
 
-      const setTagsOperation =
-        cacheHandlerValue.tags.length > 0
-          ? client.hSet(
-              options,
-              keyPrefix + sharedTagsKey,
-              key,
-              JSON.stringify(cacheHandlerValue.tags),
-            )
-          : undefined;
+      const setTagsOperation = client.hSet(
+        options,
+        keyPrefix + sharedTagsKey,
+        key,
+        JSON.stringify(cacheHandlerValue.tags | []),
+      );
 
       const setSharedTtlOperation = lifespan
         ? client.hSet(


### PR DESCRIPTION
### Problem

The current implementation assumes all cache entries must have shared tags metadata:

```js
const sharedTagKeyExists = await client.hExists(
  getTimeoutRedisCommandOptions(timeoutMs),
  keyPrefix + sharedTagsKey,
  key,
);

if (!sharedTagKeyExists) {
  await client.unlink(
    getTimeoutRedisCommandOptions(timeoutMs),
    keyPrefix + key,
  );

  return null;
}
```

This was added in #5 to fix some edge cases of revalidation issues.

However, when the cache tags are not explicitly defined in a fetch request, they are not saved in the shared tags hash map. This leads to constant cache misses and instant revalidations of fetch requests:

  1. GET - Cache handler fetches the cached data (succeeds)
  2. HEXISTS - Checks if the key exists in the shared tags hash
  3. UNLINK - Deletes the cache entry because the shared tags entry is missing
  4. Cache miss returned, origin fetch happens
  5. HSET (for TTL), EXPIREAT, SET - New cache entry is stored, without shared tags

We've experienced this in production after switching to this package, essentially disabling our cache.

### Solution

Ensure the set method always creates shared tags entries, even for empty tags.

_Alternatively, we could check for shared tags entry only if the cache value has tags defined, but I'm afraid this could lead to other inconsistencies in the future._

### Reference

Fixes https://github.com/fortedigital/nextjs-cache-handler/issues/9