### PR TITLE
fix(instrumentation): handle "/" route correctly in App Router (#17)

### DIFF
--- a/packages/nextjs-cache-handler/src/instrumentation/register-initial-cache.ts
+++ b/packages/nextjs-cache-handler/src/instrumentation/register-initial-cache.ts
@@ -231,13 +231,13 @@ export async function registerInitialCache(
     router: Router,
     revalidate: Revalidate,
   ) {
-    if (router === "app" && cachePath === "/") {
+    const isAppRouter = router === "app";
+    
+    if (isAppRouter && cachePath === "/") {
       cachePath = "/index";
     }
 
     const pathToRouteFiles = path.join(serverDistDir, router, cachePath);
-
-    const isAppRouter = router === "app";
 
     let lastModified: number | undefined;
 


### PR DESCRIPTION
This PR addresses issue #17, where the `"/"` index route in the App Router is not properly handled by the Redis cache initialization logic in the `instrumentation` module.

## Problem
In the Next.js prerender manifest, the `"/"` route has:
- key: `/`
- dataRoute: `/index.rsc`

However, the current `setPageCache` function builds the cache path directly from `cachePath`, which is `"/"` for this route. This fails to locate the correct files: `index.rsc`, `index.html`, and `index.meta`.

## Solution
This PR introduces a guard to normalize the `cachePath`:

```
if (router === "app" && cachePath === "/") {
  cachePath = "/index";
}
```

This ensures the instrumentation module can resolve and cache the index route properly.

## Notes
- Fix tested with App Router.
- I have **not** tested it with the legacy `pages` router.

Let me know if you'd like adjustments or if additional test coverage is needed.