### PR TITLE
Fixes fetch cache writing to file system allowing instrumentation to prepopulate it.

### DIFF
--- a/examples/redis-minimal/next.config.ts
+++ b/examples/redis-minimal/next.config.ts
@@ -6,6 +6,9 @@ const nextConfig: NextConfig = {
       ? require.resolve("./cache-handler.mjs")
       : undefined,
   cacheMaxMemorySize: 0, // disable default in-memory caching
+  experimental: {
+    ppr: "incremental",
+  },
 };
 
 export default nextConfig;

--- a/examples/redis-minimal/package-lock.json
+++ b/examples/redis-minimal/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fortedigital/nextjs-cache-handler": "^2.0.2",
-        "next": "15.4.3",
+        "next": "^15.5.1-canary.7",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "redis": "^5.6.1"
@@ -810,9 +810,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.4.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.3.tgz",
-      "integrity": "sha512-lKJ9KJAvaWzqurIsz6NWdQOLj96mdhuDMusLSYHw9HBe2On7BjUwU1WeRvq19x7NrEK3iOgMeSBV5qEhVH1cMw==",
+      "version": "15.5.1-canary.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.1-canary.7.tgz",
+      "integrity": "sha512-HRw70FJw9arYuzx0AiSgquT51CvCgrBlD+TzVMiZ3Dj4lIVg3OD92YwBIacDBJRLu5r6t+WAMMNtI6UfW2bgDw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -826,9 +826,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.4.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.3.tgz",
-      "integrity": "sha512-YAhZWKeEYY7LHQJiQ8fe3Y6ymfcDcTn7rDC8PDu/pdeIl1Z2LHD4uyPNuQUGCEQT//MSNv6oZCeQzZfTCKZv+A==",
+      "version": "15.5.1-canary.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.1-canary.7.tgz",
+      "integrity": "sha512-L2V1EUk/uef95ClHJMsOKOyyErFp6xvSv85SBIfL4o2kTZmenQwV5P/1RHigYDperyx46EpwSDnNSPyT3mJzog==",
       "cpu": [
         "arm64"
       ],
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.4.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.3.tgz",
-      "integrity": "sha512-ZPHRdd51xaxCMpT4viQ6h8TgYM1zPW1JIeksPY9wKlyvBVUQqrWqw8kEh1sa7/x0Ied+U7pYHkAkutrUwxbMcg==",
+      "version": "15.5.1-canary.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.1-canary.7.tgz",
+      "integrity": "sha512-Y7YqhDr+k766kF0HO5bknePGNClcvuHILmxrdliOKezsuQQs/2se3s2L++IqIYizjj6Tug03sKJB0f4YTqk2Gw==",
       "cpu": [
         "x64"
       ],
@@ -858,9 +858,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.4.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.3.tgz",
-      "integrity": "sha512-QUdqftCXC5vw5cowucqi9FeOPQ0vdMxoOHLY0J5jPdercwSJFjdi9CkEO4Xkq1eG4t1TB/BG81n6rmTsWoILnw==",
+      "version": "15.5.1-canary.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.1-canary.7.tgz",
+      "integrity": "sha512-DGkLk90WAo5fCKwlCJDSUJOpNCY4tu1p40ienaskfPXRQ+YkNC4TVxI5/NfM4EkUkxrLfwEmRepiPo4oTjDjjQ==",
       "cpu": [
         "arm64"
       ],
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.4.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.3.tgz",
-      "integrity": "sha512-HTL31NsmoafX+r5g91Yj3+q34nrn1xKmCWVuNA+fUWO4X0pr+n83uGzLyEOn0kUqbMZ40KmWx+4wsbMoUChkiQ==",
+      "version": "15.5.1-canary.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.1-canary.7.tgz",
+      "integrity": "sha512-lWS/51gq+45XsJdJRneCJof45e24DM1yWyVgLd5PNe+MP6o4GVkC80C2M6HeFZOlcQkXlPGgx88T3qtK3cytkg==",
       "cpu": [
         "arm64"
       ],
@@ -890,9 +890,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.4.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.3.tgz",
-      "integrity": "sha512-HRQLWoeFkKXd2YCEEy9GhfwOijRm37x4w5r0MMVHxBKSA6ms3JoPUXvGhfHT6srnGRcEUWNrQ2vzkHir5ZWTSw==",
+      "version": "15.5.1-canary.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.1-canary.7.tgz",
+      "integrity": "sha512-tP++NbuqZwEc195wa9Fpi3kO9Ujv95bBFuYweASZ7yjStqVY7jUPvRLdEAzcOOJhhDq1s1UM/5qK20UINKjewA==",
       "cpu": [
         "x64"
       ],
@@ -906,9 +906,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.4.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.3.tgz",
-      "integrity": "sha512-NyXUx6G7AayaRGUsVPenuwhyAoyxjQuQPaK50AXoaAHPwRuif4WmSrXUs8/Y0HJIZh8E/YXRm9H7uuGfiacpuQ==",
+      "version": "15.5.1-canary.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.1-canary.7.tgz",
+      "integrity": "sha512-1qHgJ+5UKEIAWnCxNSMwhLxCjiBZj90Tpmj2LMMSelx4OhXe6Ctb0s3mZs3QeZm6aUWRcQOZ41npjdciMsOFwQ==",
       "cpu": [
         "x64"
       ],
@@ -922,9 +922,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.4.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.3.tgz",
-      "integrity": "sha512-2CUTmpzN/7cL1a7GjdLkDFlfH3nwMwW8a6JiaAUsL9MtKmNNO3fnXqnY0Zk30fii3hVEl4dr7ztrpYt0t2CcGQ==",
+      "version": "15.5.1-canary.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.1-canary.7.tgz",
+      "integrity": "sha512-u3IjgsTZBxQpGPMqYFYLnMvq59a1RkDqFUucxgyAWbYRMtZGU3Ia1ZxOl1a6PG9EZSFvQeDqEwSP57gMsIW0Qw==",
       "cpu": [
         "arm64"
       ],
@@ -938,9 +938,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.4.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.3.tgz",
-      "integrity": "sha512-i54YgUhvrUQxQD84SjAbkfWhYkOdm/DNRAVekCHLWxVg3aUbyC6NFQn9TwgCkX5QAS2pXCJo3kFboSFvrsd7dA==",
+      "version": "15.5.1-canary.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.1-canary.7.tgz",
+      "integrity": "sha512-U/fPoC2Oc4P4VyCw7Rvy7yWoOEeu60kAzuV/UneCl+KwJ54P5PbeBYOWwTqA+d3oLNfq9vIavtIsRSBBaK1edw==",
       "cpu": [
         "x64"
       ],
@@ -4772,12 +4772,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.4.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.4.3.tgz",
-      "integrity": "sha512-uW7Qe6poVasNIE1X382nI29oxSdFJzjQzTgJFLD43MxyPfGKKxCMySllhBpvqr48f58Om+tLMivzRwBpXEytvA==",
+      "version": "15.5.1-canary.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.1-canary.7.tgz",
+      "integrity": "sha512-kuRn75pMe52I9qmib9vaKsUaCiY0OCFGbjf/29hMCy0vc5cy/desruEG3VSKDIQ1qMOZ6z6xDtfH5vifK3mW0A==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.4.3",
+        "@next/env": "15.5.1-canary.7",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -4790,14 +4790,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.4.3",
-        "@next/swc-darwin-x64": "15.4.3",
-        "@next/swc-linux-arm64-gnu": "15.4.3",
-        "@next/swc-linux-arm64-musl": "15.4.3",
-        "@next/swc-linux-x64-gnu": "15.4.3",
-        "@next/swc-linux-x64-musl": "15.4.3",
-        "@next/swc-win32-arm64-msvc": "15.4.3",
-        "@next/swc-win32-x64-msvc": "15.4.3",
+        "@next/swc-darwin-arm64": "15.5.1-canary.7",
+        "@next/swc-darwin-x64": "15.5.1-canary.7",
+        "@next/swc-linux-arm64-gnu": "15.5.1-canary.7",
+        "@next/swc-linux-arm64-musl": "15.5.1-canary.7",
+        "@next/swc-linux-x64-gnu": "15.5.1-canary.7",
+        "@next/swc-linux-x64-musl": "15.5.1-canary.7",
+        "@next/swc-win32-arm64-msvc": "15.5.1-canary.7",
+        "@next/swc-win32-x64-msvc": "15.5.1-canary.7",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/examples/redis-minimal/package.json
+++ b/examples/redis-minimal/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@fortedigital/nextjs-cache-handler": "^2.0.2",
-    "next": "15.4.3",
+    "next": "^15.5.1-canary.7",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "redis": "^5.6.1"
@@ -25,7 +25,7 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-  "eslint": "^9",
+    "eslint": "^9",
     "eslint-config-next": "15.4.3",
     "tailwindcss": "^4",
     "typescript": "^5"

--- a/examples/redis-minimal/src/app/isr-example/blog/[id]/page.tsx
+++ b/examples/redis-minimal/src/app/isr-example/blog/[id]/page.tsx
@@ -1,0 +1,35 @@
+interface Post {
+    id: string
+    title: string
+    content: string
+  }
+   
+  // Next.js will invalidate the cache when a
+  // request comes in, at most once every 60 seconds.
+  export const revalidate = 60
+   
+  export async function generateStaticParams() {
+    const posts: Post[] = await fetch('https://api.vercel.app/blog').then((res) =>
+      res.json()
+    )
+    return posts.map((post) => ({
+      id: String(post.id),
+    }))
+  }
+   
+  export default async function Page({
+    params,
+  }: {
+    params: Promise<{ id: string }>
+  }) {
+    const { id } = await params
+    const post: Post = await fetch(`https://api.vercel.app/blog/${id}`).then(
+      (res) => res.json()
+    )
+    return (
+      <main>
+        <h1>{post.title}</h1>
+        <p>{post.content}</p>
+      </main>
+    )
+  }

--- a/examples/redis-minimal/src/app/ppr-example/Example.tsx
+++ b/examples/redis-minimal/src/app/ppr-example/Example.tsx
@@ -1,0 +1,37 @@
+export async function Example({
+  searchParams,
+}: {
+  searchParams: Promise<{ characterId: string }>;
+}) {
+  const characterId = (await searchParams).characterId;
+  try {
+    const characterResponse = await fetch(
+      `https://api.sampleapis.com/futurama/characters/${characterId}`,
+      {
+        next: {
+          revalidate: 86400, // 24 hours in seconds
+          tags: ["futurama"],
+        },
+      }
+    );
+    const character = await characterResponse.json();
+    const name = character.name.first;
+    return (
+      <div>
+        <h1>Name: {name}</h1>
+        <span>{new Date().toISOString()}</span>
+      </div>
+    );
+  } catch (error) {
+    console.error("Error fetching character data:", error);
+    return (
+      <div>
+        <span>An error occurred during fetch</span>
+      </div>
+    );
+  }
+}
+
+export async function Skeleton() {
+  return <div>Loading...</div>;
+}

--- a/examples/redis-minimal/src/app/ppr-example/page.tsx
+++ b/examples/redis-minimal/src/app/ppr-example/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from "react";
+import { Example, Skeleton } from "./Example";
+
+export default function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ characterId: string }>;
+}) {
+  return (
+    <section>
+      <h1>This will be prerendered</h1>
+      <Suspense fallback={<Skeleton />}>
+        <Example searchParams={searchParams} />
+      </Suspense>
+    </section>
+  );
+}
+
+export const experimental_ppr = true;

--- a/packages/nextjs-cache-handler/src/handlers/cache-handler.ts
+++ b/packages/nextjs-cache-handler/src/handlers/cache-handler.ts
@@ -20,6 +20,8 @@ import {
   type GetIncrementalResponseCacheContext,
   type GetIncrementalFetchCacheContext,
   IncrementalCacheValue,
+  CachedFetchValue,
+  SetIncrementalFetchCacheContext,
 } from "next/dist/server/response-cache/types";
 import { resolveRevalidateValue } from "../helpers/resolveRevalidateValue";
 
@@ -221,6 +223,54 @@ export class CacheHandler implements NextCacheHandler {
     }
 
     return cacheHandlerValue;
+  }
+
+  static async #writeFetch(
+    cacheKey: string,
+    data: CachedFetchValue,
+    ctx: SetIncrementalFetchCacheContext,
+  ): Promise<void> {
+    try {
+      const fetchDataPath = path.join(
+        CacheHandler.#serverDistDir,
+        "..",
+        "cache",
+        "fetch-cache",
+        cacheKey,
+      );
+
+      await fsPromises.mkdir(path.dirname(fetchDataPath), {
+        recursive: true,
+      });
+
+      await fsPromises.writeFile(
+        fetchDataPath,
+        JSON.stringify({
+          ...data,
+          tags: ctx.fetchCache ? ctx.tags : [],
+        }),
+      );
+
+      if (CacheHandler.#debug) {
+        console.info(
+          "[CacheHandler] [handler: %s] [method: %s] [key: %s] %s",
+          "file system",
+          "set",
+          cacheKey,
+          "Successfully set value.",
+        );
+      }
+    } catch (error) {
+      if (CacheHandler.#debug) {
+        console.warn(
+          "[CacheHandler] [handler: %s] [method: %s] [key: %s] %s",
+          "file system",
+          "set",
+          cacheKey,
+          `Error: ${error}`,
+        );
+      }
+    }
   }
 
   static async #writePagesRouterPage(
@@ -705,6 +755,14 @@ export class CacheHandler implements NextCacheHandler {
       await CacheHandler.#writePagesRouterPage(
         cacheKey,
         cacheHandlerValue.value as unknown as IncrementalCachedPageValue,
+      );
+    }
+
+    if (cacheHandlerValue.value?.kind === "FETCH") {
+      await CacheHandler.#writeFetch(
+        cacheKey,
+        cacheHandlerValue.value as unknown as CachedFetchValue,
+        ctx as SetIncrementalFetchCacheContext,
       );
     }
   }

--- a/packages/nextjs-cache-handler/src/handlers/cache-handler.ts
+++ b/packages/nextjs-cache-handler/src/handlers/cache-handler.ts
@@ -676,6 +676,15 @@ export class CacheHandler implements NextCacheHandler {
       }
     }
 
+    if (CacheHandler.#debug) {
+      console.info(
+        "[CacheHandler] [method: %s] [key: %s] %s",
+        "get",
+        cacheKey,
+        `Retrieving value ${cachedData ? "found" : "not found"}.`,
+      );
+    }
+
     return cachedData ?? null;
   }
 


### PR DESCRIPTION
Solves #59 #60

In short, `CacheHandler` did not write fetch entries into `/.next/cache/fetch-cache` directory which is used by instrumentation to prepopulate cache at runtime.