### PR TITLE
Only log prefetch and read errors when the debug flag is enabled

### DIFF
--- a/packages/nextjs-cache-handler/src/instrumentation/register-initial-cache.ts
+++ b/packages/nextjs-cache-handler/src/instrumentation/register-initial-cache.ts
@@ -280,12 +280,14 @@ export async function registerInitialCache(
           )
           .then((data) => (isAppRouter ? data : (JSON.parse(data) as object)))
           .catch((error) => {
-            console.warn(
-              "[CacheHandler] [%s] %s %s",
-              "registerInitialCache",
-              "Failed to read page data, assuming it does not exist",
-              `Error: ${error}`,
-            );
+            if (debug) {
+              console.warn(
+                "[CacheHandler] [%s] %s %s",
+                "registerInitialCache",
+                "Failed to read page data, assuming it does not exist",
+                `Error: ${error}`,
+              );
+            }
 
             return undefined;
           }),
@@ -302,7 +304,7 @@ export async function registerInitialCache(
                     `Error: ${error}`,
                   );
                 }
-                
+
                 return undefined;
               })
           : undefined,


### PR DESCRIPTION
Only log prefetch read errors when the debug flag is enabled. Also for page data read errors to keep logging consistent.

Fixes: https://github.com/fortedigital/nextjs-cache-handler/issues/114