### PR TITLE
File system uses fetch and pages cache only at build phase

### DIFF
--- a/packages/nextjs-cache-handler/package-lock.json
+++ b/packages/nextjs-cache-handler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fortedigital/nextjs-cache-handler",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fortedigital/nextjs-cache-handler",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
         "cluster-key-slot": "1.1.2",

--- a/packages/nextjs-cache-handler/package.json
+++ b/packages/nextjs-cache-handler/package.json
@@ -18,7 +18,7 @@
     "next",
     "redis"
   ],
-  "version": "2.1.4",
+  "version": "2.1.5",
   "type": "module",
   "license": "MIT",
   "description": "Next.js cache handlers",

--- a/packages/nextjs-cache-handler/src/handlers/cache-handler.ts
+++ b/packages/nextjs-cache-handler/src/handlers/cache-handler.ts
@@ -24,6 +24,7 @@ import {
   SetIncrementalFetchCacheContext,
 } from "next/dist/server/response-cache/types";
 import { resolveRevalidateValue } from "../helpers/resolveRevalidateValue";
+import { PHASE_PRODUCTION_BUILD } from "next/constants.js";
 
 const PRERENDER_MANIFEST_VERSION = 4;
 
@@ -741,14 +742,21 @@ export class CacheHandler implements NextCacheHandler {
 
     await CacheHandler.#mergedHandler.set(cacheKey, cacheHandlerValue);
 
-    if (hasFallbackFalse && cacheHandlerValue.value?.kind === "APP_PAGE") {
+    if (
+      process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD &&
+      hasFallbackFalse &&
+      cacheHandlerValue.value?.kind === "APP_PAGE"
+    ) {
       await CacheHandler.#writePagesRouterPage(
         cacheKey,
         cacheHandlerValue.value as unknown as IncrementalCachedPageValue,
       );
     }
 
-    if (cacheHandlerValue.value?.kind === "FETCH") {
+    if (
+      process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD &&
+      cacheHandlerValue.value?.kind === "FETCH"
+    ) {
       await CacheHandler.#writeFetch(
         cacheKey,
         cacheHandlerValue.value as unknown as CachedFetchValue,


### PR DESCRIPTION
Fix: Limit cache writes to the production build phase.
Fixed #123.

This change ensures that cache writes to the file system using only occur during the build phase.

## Changes
- Added a condition to check `process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD` before calling `CacheHandler.#writePagesRouterPage` and `CacheHandler.#writeFetch`.

## Impact
- Prevents file system cache writes at runtime
- Ensures the file system cache isn't unnecessarily modified at runtime (and does not grow larger over time).
- No breaking changes, as this simply restricts file system writes based on the build phase. Preloading cache at instrumentation works as before.