### PR TITLE
chore: change default tag retrieval limit to 10,000

### DIFF
--- a/packages/nextjs-cache-handler/src/handlers/redis-strings.types.ts
+++ b/packages/nextjs-cache-handler/src/handlers/redis-strings.types.ts
@@ -39,7 +39,7 @@ export type CreateRedisStringsHandlerOptions<
   /**
    * Optional. The number of tags in a single query retrieved from Redis when scanning or searching for tags.
    *
-   * @default 100 // 100 tags
+   * @default 10_000 // 10,000 tags
    *
    * @remarks
    * You can adjust this value to optimize the number of commands sent to Redis when scanning or searching for tags.


### PR DESCRIPTION
# Changes
- Updated the default value for the number of tags retrieved from Redis in the redis-strings.types.ts file as there is a mismatch to the actual default value