### PR TITLE
Fix Dependabot config for pnpm monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,9 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directories:
-      - "/examples/redis-minimal"
+    # Use root directory for pnpm monorepo - the pnpm-lock.yaml is at the root
+    # and Dependabot needs to update it when modifying any workspace package
+    directory: "/"
     schedule:
       interval: "monthly"
     ignore:


### PR DESCRIPTION
## Summary

- Changed Dependabot to monitor the root directory (`/`) instead of subdirectory (`/examples/redis-minimal`)
- This ensures the `pnpm-lock.yaml` at the root is properly updated when dependencies in workspace packages are modified

## Problem

The previous configuration pointed to `/examples/redis-minimal` which caused Dependabot PRs to fail CI because:
1. Dependabot would update `package.json` in the subdirectory
2. But the `pnpm-lock.yaml` at the root was not being updated
3. This caused `pnpm install --frozen-lockfile` to fail with lockfile mismatch errors

## Test plan

- [x] Manually triggered Node.js CI workflow - passes successfully
- Dependabot will now create PRs that properly update the root lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)