### PR TITLE
fix: use route cache revalidation

### DIFF
--- a/packages/nextjs-cache-handler/src/helpers/resolveRevalidateValue.test.ts
+++ b/packages/nextjs-cache-handler/src/helpers/resolveRevalidateValue.test.ts
@@ -1,0 +1,30 @@
+import { resolveRevalidateValue } from "./resolveRevalidateValue";
+
+describe("resolveRevalidateValue", () => {
+  it("uses cacheControl revalidate for app routes", () => {
+    const value = { kind: "APP_ROUTE" };
+    const context = {
+      cacheControl: { revalidate: 3600 },
+      revalidate: 31536000,
+    };
+
+    expect(resolveRevalidateValue(value as never, context as never)).toBe(3600);
+  });
+
+  it("keeps the existing app page behavior", () => {
+    const value = { kind: "APP_PAGE" };
+    const context = {
+      cacheControl: { revalidate: 600 },
+      revalidate: 31536000,
+    };
+
+    expect(resolveRevalidateValue(value as never, context as never)).toBe(600);
+  });
+
+  it("falls back to context revalidate when cache control is absent", () => {
+    const value = { kind: "APP_ROUTE" };
+    const context = { revalidate: 120 };
+
+    expect(resolveRevalidateValue(value as never, context as never)).toBe(120);
+  });
+});

--- a/packages/nextjs-cache-handler/src/helpers/resolveRevalidateValue.ts
+++ b/packages/nextjs-cache-handler/src/helpers/resolveRevalidateValue.ts
@@ -33,7 +33,8 @@ export function resolveRevalidateValue(
     revalidate = cachedFetchValue.revalidate;
   } else if (
     cachedPageValue?.kind === "APP_PAGE" ||
-    cachedPageValue?.kind === "PAGES"
+    cachedPageValue?.kind === "PAGES" ||
+    cachedPageValue?.kind === "APP_ROUTE"
   ) {
     revalidate = responseCacheCtx.cacheControl?.revalidate;
   }


### PR DESCRIPTION
## Summary

- use `cacheControl.revalidate` for `APP_ROUTE` cache entries
- add focused regression coverage for route entries, existing app pages, and fallback behavior

This fixes route handlers falling back to the default stale age when Next.js provides the route-level value through `cacheControl`.

## Validation

- `git diff --check`
- Added Jest coverage in `resolveRevalidateValue.test.ts`

The package dependencies are not installed in this sparse checkout. The package Jest command timed out while the pnpm runtime attempted workspace dependency resolution, so I could not claim a local test pass. The upstream checks should run the full package suite.

The implementation was prepared with AI assistance and reviewed by me. I am responsible for the changes and this submission.

Closes #224