### PR TITLE
fix: resolve revalidate from cacheControl for null (notFound) page values

### DIFF
--- a/packages/nextjs-cache-handler/src/helpers/resolveRevalidateValue.test.ts
+++ b/packages/nextjs-cache-handler/src/helpers/resolveRevalidateValue.test.ts
@@ -1,0 +1,59 @@
+import { resolveRevalidateValue } from "./resolveRevalidateValue";
+
+describe("resolveRevalidateValue", () => {
+  it("reads revalidate from a FETCH value", () => {
+    const result = resolveRevalidateValue(
+      { kind: "FETCH", revalidate: 60 } as any,
+      {} as any,
+    );
+
+    expect(result).toBe(60);
+  });
+
+  it("reads revalidate from ctx.cacheControl for an APP_PAGE value", () => {
+    const result = resolveRevalidateValue({ kind: "APP_PAGE" } as any, {
+      cacheControl: { revalidate: 30 },
+    } as any);
+
+    expect(result).toBe(30);
+  });
+
+  it("reads revalidate from ctx.cacheControl for a PAGES value", () => {
+    const result = resolveRevalidateValue({ kind: "PAGES" } as any, {
+      cacheControl: { revalidate: 30 },
+    } as any);
+
+    expect(result).toBe(30);
+  });
+
+  it("reads revalidate from ctx.cacheControl when the incremental cache value is null (getStaticProps notFound: true)", () => {
+    const result = resolveRevalidateValue(null as any, {
+      cacheControl: { revalidate: 10 },
+    } as any);
+
+    expect(result).toBe(10);
+  });
+
+  it("reads revalidate from ctx.cacheControl when the incremental cache value is undefined", () => {
+    const result = resolveRevalidateValue(undefined as any, {
+      cacheControl: { revalidate: 10 },
+    } as any);
+
+    expect(result).toBe(10);
+  });
+
+  it("falls back to ctx.revalidate when the value has no recognized kind", () => {
+    const result = resolveRevalidateValue({ kind: "UNKNOWN" } as any, {
+      cacheControl: { revalidate: 10 },
+      revalidate: 5,
+    } as any);
+
+    expect(result).toBe(5);
+  });
+
+  it("returns undefined when neither cacheControl.revalidate nor ctx.revalidate is set", () => {
+    const result = resolveRevalidateValue(null as any, {} as any);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/nextjs-cache-handler/src/helpers/resolveRevalidateValue.ts
+++ b/packages/nextjs-cache-handler/src/helpers/resolveRevalidateValue.ts
@@ -33,7 +33,14 @@ export function resolveRevalidateValue(
     revalidate = cachedFetchValue.revalidate;
   } else if (
     cachedPageValue?.kind === "APP_PAGE" ||
-    cachedPageValue?.kind === "PAGES"
+    cachedPageValue?.kind === "PAGES" ||
+    // `getStaticProps`/`getServerSideProps` returning `notFound: true` has no
+    // page value to cache, so Next.js calls `set()` with `incrementalCacheValue`
+    // set to `null` (no `kind`). The intended revalidate time still lives on
+    // `ctx.cacheControl.revalidate` in that case, so read it here too instead of
+    // silently falling through to the unpopulated `ctx.revalidate` below and
+    // defaulting to `defaultStaleAge`.
+    cachedPageValue == null
   ) {
     revalidate = responseCacheCtx.cacheControl?.revalidate;
   }


### PR DESCRIPTION
## Summary

`resolveRevalidateValue()` only reads `ctx.cacheControl.revalidate` when the cached value's `kind` is `"APP_PAGE"` or `"PAGES"`. But when a Pages Router `getStaticProps`/`getServerSideProps` returns `notFound: true`, there's no page content to cache, so Next.js's response cache calls `CacheHandler#set()` with `incrementalCacheValue` set to `null` — it has no `kind` at all.

That means the `else if` never matches for `notFound: true` responses, `revalidate` falls through to `ctx.revalidate`, which the pages-router response cache never actually populates (`response-cache/index.js` only ever passes `{ cacheControl, isRoutePPREnabled, isFallback }` into `incrementalCache.set()`), and the entry silently gets `defaultStaleAge` instead of the `revalidate` value the page actually returned alongside `notFound: true`.

### Repro

```js
// pages/[stationId].tsx
export const getStaticProps = async (context) => {
  if (invalid) {
    return { notFound: true, revalidate: 10 };
  }
  // ...
  return { props: {...}, revalidate: 30 };
};
```

- Success path: cached value has `kind: "PAGES"` → `ctx.cacheControl.revalidate` (30) is read correctly.
- `notFound: true` path: cached value is `null` → falls through to `ctx.revalidate` (`undefined`) → `defaultStaleAge` is used instead of `10`, regardless of what the page returned.

With the default `defaultStaleAge` of `31536000` (1 year), every `notFound: true` response ends up with a ~1 year stale age in the underlying store no matter what `revalidate` the page specifies.

## Fix

Also read `ctx.cacheControl.revalidate` when the incremental cache value is `null`/`undefined`, since that's exactly where the intended revalidate time already lives for `notFound: true` responses.

## Test plan

- Added `resolveRevalidateValue.test.ts` covering `FETCH`, `APP_PAGE`, `PAGES`, `null` (the fix), `undefined`, unknown `kind`, and the no-value/no-ctx fallback cases.
- `pnpm test` in `packages/nextjs-cache-handler` — all 34 tests pass.
- `pnpm build` (`tsup --dts-resolve`) — builds cleanly, no type errors.

Happy to adjust the approach if you'd prefer handling this differently (e.g. inside `CacheHandler#set()` instead of `resolveRevalidateValue()`).