### PR TITLE
fix(redis-strings): preserve native Redis abort handling

### DIFF
--- a/packages/nextjs-cache-handler/src/handlers/redis-strings.ts
+++ b/packages/nextjs-cache-handler/src/handlers/redis-strings.ts
@@ -53,7 +53,11 @@ export default function createHandler({
 }: CreateRedisStringsHandlerOptions<
   RedisClientType | RedisClusterCacheAdapter
 >): Handler {
-  const client = withAbortSignalProxy(innerClient);
+  const client =
+    "withAbortSignal" in innerClient &&
+    typeof innerClient.withAbortSignal === "function"
+      ? innerClient
+      : withAbortSignalProxy(innerClient);
   const revalidatedTagsKey = keyPrefix + REVALIDATED_TAGS_KEY;
 
   function assertClientIsReady(): void {

--- a/packages/nextjs-cache-handler/src/handlers/redis-strings.types.ts
+++ b/packages/nextjs-cache-handler/src/handlers/redis-strings.types.ts
@@ -48,6 +48,10 @@ export type CreateRedisStringsHandlerOptions<
    *
    * @remarks
    * To disable timeout of Redis operations, set this option to 0.
+   * With clients that provide native abort support, queued commands that have not
+   * been written to the socket are cancelled. Commands already written to the
+   * socket cannot be cancelled. For other clients, the timeout only stops waiting
+   * for the result; the underlying command continues to run.
    */
   timeoutMs?: number;
   /**

--- a/packages/nextjs-cache-handler/src/redis-strings.test.ts
+++ b/packages/nextjs-cache-handler/src/redis-strings.test.ts
@@ -1,0 +1,139 @@
+import type { RedisClientType } from "@redis/client";
+import type { CacheHandlerValue } from "./handlers/cache-handler.types";
+import createHandler from "./handlers/redis-strings";
+
+function useControlledTimeoutSignal(): AbortController {
+  const controller = new AbortController();
+  jest.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
+  return controller;
+}
+
+describe("redis-strings abort signals", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("uses an inherited native withAbortSignal implementation", async () => {
+    const unlink = jest.fn().mockResolvedValue(1);
+    const hDel = jest.fn().mockResolvedValue(1);
+    const signalClient = { unlink, hDel };
+    const withAbortSignal = jest.fn().mockReturnValue(signalClient);
+    const client = Object.assign(Object.create({ withAbortSignal }), {
+      isReady: true,
+      unlink: jest.fn().mockResolvedValue(1),
+      hDel: jest.fn().mockResolvedValue(1),
+    }) as RedisClientType;
+
+    await createHandler({ client }).delete!("cache-key");
+
+    expect(withAbortSignal).toHaveBeenCalledTimes(3);
+    expect(withAbortSignal).toHaveBeenCalledWith(expect.any(AbortSignal));
+    expect(unlink).toHaveBeenCalledWith("cache-key");
+    expect(hDel).toHaveBeenNthCalledWith(1, "__sharedTags__", "cache-key");
+    expect(hDel).toHaveBeenNthCalledWith(2, "__sharedTagsTtl__", "cache-key");
+    expect(client.unlink).not.toHaveBeenCalled();
+    expect(client.hDel).not.toHaveBeenCalled();
+  });
+
+  it("passes the timeout signal to the native command", async () => {
+    const controller = useControlledTimeoutSignal();
+    let commandWasCancelled = false;
+    const withAbortSignal = jest.fn((signal: AbortSignal) => ({
+      unlink: jest.fn(
+        () =>
+          new Promise<number>((_, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => {
+                commandWasCancelled = true;
+                reject(new Error("Native command aborted"));
+              },
+              { once: true },
+            );
+          }),
+      ),
+    }));
+    const client = {
+      isReady: true,
+      withAbortSignal,
+      unlink: jest.fn(() => new Promise<number>(() => undefined)),
+    } as unknown as RedisClientType;
+
+    const operation = createHandler({ client, timeoutMs: 1 }).delete!(
+      "cache-key",
+    );
+    controller.abort();
+
+    await expect(operation).rejects.toThrow("Native command aborted");
+
+    expect(withAbortSignal).toHaveBeenCalledWith(expect.any(AbortSignal));
+    expect(commandWasCancelled).toBe(true);
+    expect(client.unlink).not.toHaveBeenCalled();
+  });
+
+  it("routes serialized set payloads through the native abort client", async () => {
+    const hSet = jest.fn().mockResolvedValue(1);
+    const set = jest.fn().mockResolvedValue("OK");
+    const withAbortSignal = jest.fn().mockReturnValue({ hSet, set });
+    const client = {
+      isReady: true,
+      withAbortSignal,
+      hSet: jest.fn().mockResolvedValue(1),
+      set: jest.fn().mockResolvedValue("OK"),
+    } as unknown as RedisClientType;
+    const serializedValue = "serialized-page-payload";
+    const valueSerializer = {
+      serialize: jest.fn().mockReturnValue(serializedValue),
+      deserialize: jest.fn(),
+    };
+    const cacheValue = {
+      value: null,
+      lastModified: Date.now(),
+      tags: [],
+      lifespan: null,
+    } as unknown as CacheHandlerValue;
+
+    await createHandler({ client, valueSerializer }).set(
+      "cache-key",
+      cacheValue,
+    );
+
+    expect(withAbortSignal).toHaveBeenCalledTimes(2);
+    expect(hSet).toHaveBeenCalledWith("__sharedTags__", "cache-key", "[]");
+    expect(set).toHaveBeenCalledWith("cache-key", serializedValue, undefined);
+    expect(client.hSet).not.toHaveBeenCalled();
+    expect(client.set).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["is missing", {}],
+    ["is not callable", { withAbortSignal: undefined }],
+  ])(
+    "falls back to the abort proxy when withAbortSignal %s",
+    async (_, abortSignalProperty) => {
+      const controller = useControlledTimeoutSignal();
+      let completeCommand!: () => void;
+      const underlyingCommand = new Promise<number>((resolve) => {
+        completeCommand = () => resolve(1);
+      });
+      const unlink = jest.fn(() => underlyingCommand);
+      const client = {
+        isReady: true,
+        unlink,
+        ...abortSignalProperty,
+      } as unknown as RedisClientType;
+
+      const operation = createHandler({ client, timeoutMs: 1 }).delete!(
+        "cache-key",
+      );
+      controller.abort();
+
+      await expect(operation).rejects.toThrow("Operation aborted");
+
+      expect(unlink).toHaveBeenCalledWith("cache-key");
+
+      completeCommand();
+      await expect(underlyingCommand).resolves.toBe(1);
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- prefer node-redis native `withAbortSignal` so aborted queued commands are removed instead of retaining serialized payloads
- retain the abort proxy fallback for cluster and other clients without native support
- document native and fallback timeout semantics
- add deterministic regression coverage for native cancellation, serialized `SET` payloads, inherited methods, and fallback behavior

## Testing
- `pnpm exec jest --runInBand`
- `pnpm exec tsc --project tsconfig.jest.json --noEmit`
- `pnpm build`
- `git diff --check`

Closes #235